### PR TITLE
Add Demucs stem splitting web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+*.log

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "stemsplitter",
+  "version": "1.0.0",
+  "description": "Web app for splitting MP3s into stems using Demucs",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "next": "14.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "formidable": "3.5.1"
+  }
+}

--- a/pages/api/separate.js
+++ b/pages/api/separate.js
@@ -1,0 +1,64 @@
+import formidable from 'formidable';
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const form = formidable({ multiples: false, uploadDir: '/tmp', keepExtensions: true });
+
+  form.parse(req, (err, fields, files) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Upload failed' });
+    }
+    const file = files.file;
+    const input = Array.isArray(file) ? file[0] : file;
+    const outDir = path.join('/tmp', path.basename(input.filepath) + '_out');
+
+    const demucs = spawn('demucs', ['-o', outDir, input.filepath]);
+
+    demucs.on('error', (e) => {
+      console.error(e);
+      return res.status(500).json({ error: 'Demucs execution failed' });
+    });
+
+    demucs.on('close', (code) => {
+      if (code !== 0) {
+        return res.status(500).json({ error: 'Demucs exited with code ' + code });
+      }
+      try {
+        const songName = path.parse(input.originalFilename).name;
+        const stemPath = path.join(outDir, 'htdemucs', songName);
+        const stems = {};
+        const files = fs.readdirSync(stemPath);
+        files.forEach((stemFile) => {
+          const full = path.join(stemPath, stemFile);
+          const mp3Path = full.replace(/\.wav$/, '.mp3');
+          // Convert to mp3 using ffmpeg
+          spawn('ffmpeg', ['-y', '-i', full, mp3Path]).on('close', () => {
+            const data = fs.readFileSync(mp3Path).toString('base64');
+            const name = stemFile.replace(/\.wav$/, '');
+            stems[name] = `data:audio/mpeg;base64,${data}`;
+            if (Object.keys(stems).length === files.length) {
+              res.status(200).json({ stems });
+            }
+          });
+        });
+      } catch (e) {
+        console.error(e);
+        return res.status(500).json({ error: 'Failed to prepare stems' });
+      }
+    });
+  });
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+
+export default function Home() {
+  const [stems, setStems] = useState({});
+  const [loading, setLoading] = useState(false);
+
+  const handleUpload = async (event) => {
+    event.preventDefault();
+    const file = event.target.file.files[0];
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    setLoading(true);
+    try {
+      const res = await fetch('/api/separate', {
+        method: 'POST',
+        body: formData
+      });
+      if (!res.ok) throw new Error('Separation failed');
+      const data = await res.json();
+      setStems(data.stems);
+    } catch (err) {
+      console.error(err);
+      alert('Failed to split file');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main style={{ fontFamily: 'sans-serif', padding: '2rem' }}>
+      <h1>Stem Splitter</h1>
+      <form onSubmit={handleUpload}>
+        <input type="file" name="file" accept="audio/mpeg" />
+        <button type="submit" disabled={loading}>Split</button>
+      </form>
+      {loading && <p>Processing…</p>}
+      {Object.keys(stems).length > 0 && (
+        <div style={{ marginTop: '2rem' }}>
+          {Object.entries(stems).map(([name, url]) => (
+            <div key={name} style={{ marginBottom: '1rem' }}>
+              <h3>{name}</h3>
+              <audio controls src={url}></audio>
+              <div>
+                <a href={url} download={`${name}.mp3`}>Download</a>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add Next.js frontend for uploading MP3 and playing separated stems
- add API route that invokes demucs and ffmpeg to split and encode stems
- configure package and ignore files for Vercel deployment

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9345d7d48332a998a16196e34a2f