### PR TITLE
Add isometric room builder skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Stemsplitter Plaza
+
+An isometric room-building sandbox inspired by the classic Habbo Hotel look and feel. This project focuses on providing a clean skeleton that demonstrates how an isometric grid, tile placement, and simple furniture rendering can work inside a modern browser with vanilla JavaScript.
+
+## Features
+
+- 🎨 **Isometric floor renderer** – draws a diamond grid with multiple floor swatches.
+- 🪑 **Basic furnishing system** – place or replace colourful voxel-style furniture blocks.
+- 🧹 **Utility tools** – clear tiles with the broom and toggle the grid overlay.
+- 🧭 **Inspector HUD** – surface details about the hovered tile including floor and furniture types.
+
+## Getting started
+
+No build step is required. Open `index.html` in a modern browser and start arranging tiles. For best results, serve the directory through a simple static file server (for example `python -m http.server`) and navigate to `http://localhost:8000`.
+
+## Extending the skeleton
+
+- Add more floor textures or item definitions in `src/main.js` to expand the palette.
+- Implement avatar sprites or multi-tile furniture by extending `Room` and the `IsometricRenderer`.
+- Persist user creations by serializing the `Room` state via the provided `serialize()` helper.
+
+This foundation is intentionally lightweight to stay framework-agnostic and easy to extend.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stemsplitter Isometric Room Builder</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="top-bar">
+    <div class="brand">
+      <h1>Stemsplitter Plaza</h1>
+      <p class="tagline">Build an isometric hangout inspired by Habbo Hotel.</p>
+    </div>
+  </header>
+  <main class="app">
+    <aside class="sidebar">
+      <section class="palette" id="palette">
+        <h2>Palette</h2>
+        <div class="palette-group" data-group="flooring">
+          <h3>Flooring</h3>
+          <div class="palette-options" id="floor-tools"></div>
+        </div>
+        <div class="palette-group" data-group="furni">
+          <h3>Furniture</h3>
+          <div class="palette-options" id="furni-tools"></div>
+        </div>
+        <div class="palette-group" data-group="utility">
+          <h3>Utility</h3>
+          <div class="palette-options" id="utility-tools"></div>
+        </div>
+      </section>
+      <section class="controls">
+        <h2>Room Controls</h2>
+        <button id="reset-room" class="control-button">Reset room</button>
+        <label class="toggle">
+          <input type="checkbox" id="toggle-grid" checked />
+          <span>Show grid overlay</span>
+        </label>
+      </section>
+    </aside>
+    <section class="stage">
+      <canvas id="room-canvas" width="960" height="640"></canvas>
+      <div class="hud">
+        <div class="hud-line" id="hover-readout">Hover over a tile to inspect it.</div>
+        <div class="hud-line" id="tool-readout">Active tool: <span class="value"></span></div>
+      </div>
+    </section>
+    <aside class="inspector">
+      <h2>Inspector</h2>
+      <dl class="inspector-list">
+        <div>
+          <dt>Hovered tile</dt>
+          <dd id="inspector-tile">None</dd>
+        </div>
+        <div>
+          <dt>Floor</dt>
+          <dd id="inspector-floor">-</dd>
+        </div>
+        <div>
+          <dt>Item</dt>
+          <dd id="inspector-item">-</dd>
+        </div>
+      </dl>
+      <section class="guide">
+        <h3>How to build</h3>
+        <ul>
+          <li>Select a flooring or furniture option from the palette.</li>
+          <li>Click on the isometric grid to place the selection.</li>
+          <li>Choose the broom to clear tiles or remove furniture.</li>
+        </ul>
+      </section>
+    </aside>
+  </main>
+  <footer class="footer">Crafted for the Habbo-inspired Stemsplitter project.</footer>
+  <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,351 @@
+import { Room } from './room.js';
+import { IsometricRenderer } from './renderer.js';
+
+const FLOOR_TYPES = {
+  void: {
+    id: 'void',
+    label: 'Empty',
+    color: '#1b243b',
+    stroke: 'rgba(0, 0, 0, 0.45)',
+  },
+  wood: {
+    id: 'wood',
+    label: 'Golden Wood',
+    color: '#c7834a',
+    stroke: '#8c5b33',
+  },
+  tile: {
+    id: 'tile',
+    label: 'Ice Tile',
+    color: '#6f9dd5',
+    stroke: '#4d74a7',
+  },
+  carpet: {
+    id: 'carpet',
+    label: 'Sunset Carpet',
+    color: '#d55a92',
+    stroke: '#9d3a67',
+  },
+  grass: {
+    id: 'grass',
+    label: 'Emerald Turf',
+    color: '#54b36a',
+    stroke: '#3e8c4d',
+  },
+};
+
+const ITEM_TYPES = {
+  seat: {
+    id: 'seat',
+    label: 'Retro Seat',
+    color: '#f9b946',
+    height: 34,
+  },
+  table: {
+    id: 'table',
+    label: 'Cafe Table',
+    color: '#bed5f5',
+    height: 26,
+  },
+  lamp: {
+    id: 'lamp',
+    label: 'Floor Lamp',
+    color: '#ffe066',
+    height: 54,
+  },
+};
+
+const TOOL_GROUPS = [
+  {
+    id: 'flooring',
+    buttons: [
+      { id: 'floor-wood', label: 'Wood Floor', icon: '🪵', kind: 'floor', floor: 'wood' },
+      { id: 'floor-tile', label: 'Ice Tile', icon: '🧊', kind: 'floor', floor: 'tile' },
+      { id: 'floor-carpet', label: 'Carpet', icon: '🪄', kind: 'floor', floor: 'carpet' },
+      { id: 'floor-grass', label: 'Turf', icon: '🌿', kind: 'floor', floor: 'grass' },
+    ],
+  },
+  {
+    id: 'furni',
+    buttons: [
+      { id: 'item-seat', label: 'Retro Seat', icon: '🪑', kind: 'item', item: 'seat' },
+      { id: 'item-table', label: 'Table', icon: '🧋', kind: 'item', item: 'table' },
+      { id: 'item-lamp', label: 'Lamp', icon: '💡', kind: 'item', item: 'lamp' },
+    ],
+  },
+  {
+    id: 'utility',
+    buttons: [{ id: 'tool-broom', label: 'Broom', icon: '🧹', kind: 'broom' }],
+  },
+];
+
+function setup() {
+  const room = new Room(12, 12, { defaultFloor: 'void' });
+  const canvas = document.getElementById('room-canvas');
+  const stage = document.querySelector('.stage');
+  if (!canvas || !stage) {
+    console.error('Unable to initialize the room builder: missing canvas or stage element.');
+    return;
+  }
+  const renderer = new IsometricRenderer(canvas, room, {
+    floorDefinitions: FLOOR_TYPES,
+    itemDefinitions: ITEM_TYPES,
+  });
+  const initialWidth = stage.clientWidth || canvas.clientWidth || canvas.width;
+  const initialHeight = stage.clientHeight || canvas.clientHeight || canvas.height;
+  renderer.resize(initialWidth, initialHeight);
+
+  const state = {
+    activeToolId: 'floor-wood',
+    hoverTile: null,
+  };
+
+  const paletteRoots = {
+    flooring: document.getElementById('floor-tools'),
+    furni: document.getElementById('furni-tools'),
+    utility: document.getElementById('utility-tools'),
+  };
+
+  const paletteButtons = new Map();
+  const toolsById = new Map();
+  TOOL_GROUPS.forEach((group) => {
+    group.buttons.forEach((tool) => toolsById.set(tool.id, tool));
+  });
+
+  const hoverReadout = document.getElementById('hover-readout');
+  const toolReadoutValue = document.querySelector('#tool-readout .value');
+  const inspectorTile = document.getElementById('inspector-tile');
+  const inspectorFloor = document.getElementById('inspector-floor');
+  const inspectorItem = document.getElementById('inspector-item');
+  const gridToggle = document.getElementById('toggle-grid');
+  const resetButton = document.getElementById('reset-room');
+
+  function buildPalette() {
+    TOOL_GROUPS.forEach((group) => {
+      const container = paletteRoots[group.id];
+      if (!container) {
+        return;
+      }
+      container.innerHTML = '';
+      group.buttons.forEach((tool) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'palette-item';
+        button.dataset.toolId = tool.id;
+        button.title = tool.label;
+
+        if (tool.kind === 'floor' || tool.kind === 'item') {
+          const swatch = document.createElement('span');
+          swatch.className = 'swatch';
+          const palette = tool.kind === 'floor' ? FLOOR_TYPES : ITEM_TYPES;
+          const reference = palette[tool.floor ?? tool.item];
+          swatch.style.background = reference?.color ?? '#ccc';
+          button.appendChild(swatch);
+        } else {
+          const swatch = document.createElement('span');
+          swatch.className = 'swatch';
+          swatch.style.background = 'linear-gradient(135deg, #ffef9c, #ffbd4a)';
+          button.appendChild(swatch);
+        }
+
+        const label = document.createElement('span');
+        label.className = 'label';
+        label.textContent = tool.icon ? `${tool.icon} ${tool.label}` : tool.label;
+        button.appendChild(label);
+
+        button.addEventListener('click', () => setActiveTool(tool.id));
+
+        container.appendChild(button);
+        paletteButtons.set(tool.id, button);
+      });
+    });
+  }
+
+  function setActiveTool(toolId) {
+    if (!toolsById.has(toolId)) {
+      return;
+    }
+    const previous = paletteButtons.get(state.activeToolId);
+    if (previous) {
+      previous.classList.remove('active');
+    }
+    state.activeToolId = toolId;
+    const current = paletteButtons.get(toolId);
+    if (current) {
+      current.classList.add('active');
+    }
+    updateToolReadout();
+  }
+
+  function updateToolReadout() {
+    const tool = toolsById.get(state.activeToolId);
+    if (toolReadoutValue) {
+      toolReadoutValue.textContent = tool ? tool.label : 'None';
+    }
+  }
+
+  function describeFloor(id) {
+    if (!id) {
+      return 'None';
+    }
+    const definition = FLOOR_TYPES[id];
+    if (!definition) {
+      return id;
+    }
+    if (id === 'void') {
+      return 'Empty';
+    }
+    return definition.label;
+  }
+
+  function describeItem(item) {
+    if (!item) {
+      return 'None';
+    }
+    const definition = ITEM_TYPES[item.type];
+    return definition ? definition.label : item.type;
+  }
+
+  function updateInspector() {
+    if (!hoverReadout || !inspectorTile || !inspectorFloor || !inspectorItem) {
+      return;
+    }
+    if (!state.hoverTile) {
+      inspectorTile.textContent = 'None';
+      inspectorFloor.textContent = '-';
+      inspectorItem.textContent = '-';
+      hoverReadout.textContent = 'Hover over a tile to inspect it.';
+      return;
+    }
+    const { x, y } = state.hoverTile;
+    inspectorTile.textContent = `${x}, ${y}`;
+    const floorId = room.getFloor(x, y);
+    inspectorFloor.textContent = describeFloor(floorId);
+    const item = room.itemAt(x, y);
+    inspectorItem.textContent = describeItem(item);
+    hoverReadout.textContent = `Tile (${x}, ${y}) • Floor: ${describeFloor(floorId)} • Item: ${describeItem(item)}`;
+  }
+
+  function translatePointer(event) {
+    const rect = canvas.getBoundingClientRect();
+    const cssWidth = rect.width || 1;
+    const cssHeight = rect.height || 1;
+    const ratio = renderer.pixelRatio || 1;
+    const renderWidth = canvas.width / ratio;
+    const renderHeight = canvas.height / ratio;
+    const x = ((event.clientX - rect.left) / cssWidth) * renderWidth;
+    const y = ((event.clientY - rect.top) / cssHeight) * renderHeight;
+    return { x, y };
+  }
+
+  function updateHoverFromEvent(event) {
+    const point = translatePointer(event);
+    const tile = renderer.pickTile(point.x, point.y);
+    const current = state.hoverTile;
+    const changed =
+      (current && tile && (current.x !== tile.x || current.y !== tile.y)) ||
+      (!current && tile) ||
+      (current && !tile);
+    state.hoverTile = tile;
+    renderer.setHoverTile(tile);
+    if (changed) {
+      renderer.render();
+    }
+    updateInspector();
+  }
+
+  function applyTool(tile) {
+    const tool = toolsById.get(state.activeToolId);
+    if (!tile || !tool) {
+      return;
+    }
+
+    if (tool.kind === 'floor' && tool.floor) {
+      room.setFloor(tile.x, tile.y, tool.floor);
+    } else if (tool.kind === 'item' && tool.item) {
+      const definition = ITEM_TYPES[tool.item];
+      room.placeItem(tile.x, tile.y, definition);
+    } else if (tool.kind === 'broom') {
+      const removed = room.removeItem(tile.x, tile.y);
+      if (!removed) {
+        room.setFloor(tile.x, tile.y, room.defaultFloor);
+      }
+    }
+
+    renderer.render();
+    updateInspector();
+  }
+
+  canvas.addEventListener('mousemove', (event) => {
+    updateHoverFromEvent(event);
+  });
+
+  canvas.addEventListener('mouseleave', () => {
+    state.hoverTile = null;
+    renderer.setHoverTile(null);
+    renderer.render();
+    updateInspector();
+  });
+
+  canvas.addEventListener('click', (event) => {
+    updateHoverFromEvent(event);
+    if (state.hoverTile) {
+      applyTool(state.hoverTile);
+    }
+  });
+
+  canvas.addEventListener('contextmenu', (event) => {
+    event.preventDefault();
+    const point = translatePointer(event);
+    const tile = renderer.pickTile(point.x, point.y);
+    if (!tile) {
+      return;
+    }
+    const removed = room.removeItem(tile.x, tile.y);
+    if (!removed) {
+      room.setFloor(tile.x, tile.y, room.defaultFloor);
+    }
+    state.hoverTile = tile;
+    renderer.setHoverTile(tile);
+    renderer.render();
+    updateInspector();
+  });
+
+  if (gridToggle) {
+    gridToggle.addEventListener('change', () => {
+      renderer.setGridVisible(gridToggle.checked);
+    });
+    renderer.setGridVisible(gridToggle.checked);
+  } else {
+    renderer.setGridVisible(true);
+  }
+
+  if (resetButton) {
+    resetButton.addEventListener('click', () => {
+      room.clear();
+      renderer.render();
+      updateInspector();
+    });
+  }
+
+  if (typeof ResizeObserver !== 'undefined') {
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        renderer.resize(width, height);
+      }
+    });
+    observer.observe(stage);
+  } else {
+    window.addEventListener('resize', () => {
+      renderer.resize(stage.clientWidth, stage.clientHeight);
+    });
+  }
+
+  buildPalette();
+  setActiveTool(state.activeToolId);
+  renderer.render();
+  updateInspector();
+}
+
+window.addEventListener('DOMContentLoaded', setup);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1,0 +1,296 @@
+const DEFAULT_FLOOR = {
+  color: '#2f3d62',
+  stroke: 'rgba(10, 14, 28, 0.6)',
+};
+
+const DEFAULT_ITEM = {
+  color: '#ffb347',
+  height: 28,
+};
+
+function adjustColor(hex, amount) {
+  if (!hex || typeof hex !== 'string' || !hex.startsWith('#')) {
+    return hex;
+  }
+  const normalized = hex.slice(1);
+  if (normalized.length !== 6) {
+    return hex;
+  }
+  const num = parseInt(normalized, 16);
+  const r = (num >> 16) & 0xff;
+  const g = (num >> 8) & 0xff;
+  const b = num & 0xff;
+  const clamp = (value) => Math.max(0, Math.min(255, value));
+  const nextR = clamp(r + amount);
+  const nextG = clamp(g + amount);
+  const nextB = clamp(b + amount);
+  return `#${((nextR << 16) | (nextG << 8) | nextB).toString(16).padStart(6, '0')}`;
+}
+
+export class IsometricRenderer {
+  constructor(
+    canvas,
+    room,
+    {
+      tileWidth = 64,
+      tileHeight = 32,
+      floorDefinitions = {},
+      itemDefinitions = {},
+    } = {}
+  ) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.room = room;
+    this.tileWidth = tileWidth;
+    this.tileHeight = tileHeight;
+    this.floorDefinitions = floorDefinitions;
+    this.itemDefinitions = itemDefinitions;
+
+    this.hoverTile = null;
+    this.showGrid = true;
+    this.originX = canvas.width / 2;
+    this.originY = tileHeight;
+
+    this.resize(canvas.clientWidth || canvas.width, canvas.clientHeight || canvas.height);
+  }
+
+  setFloorDefinitions(definitions) {
+    this.floorDefinitions = definitions;
+  }
+
+  setItemDefinitions(definitions) {
+    this.itemDefinitions = definitions;
+  }
+
+  setGridVisible(visible) {
+    this.showGrid = Boolean(visible);
+    this.render();
+  }
+
+  setHoverTile(tile) {
+    this.hoverTile = tile;
+  }
+
+  resize(width, height) {
+    const ratio = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+    const safeWidth = Math.max(1, Math.floor(width));
+    const safeHeight = Math.max(1, Math.floor(height));
+
+    this.canvas.width = safeWidth * ratio;
+    this.canvas.height = safeHeight * ratio;
+    this.canvas.style.width = `${safeWidth}px`;
+    this.canvas.style.height = `${safeHeight}px`;
+    this.ctx.setTransform(1, 0, 0, 1, 0, 0);
+    this.ctx.scale(ratio, ratio);
+    this.pixelRatio = ratio;
+
+    this.updateOrigin();
+    this.render();
+  }
+
+  updateOrigin() {
+    const ratio = this.pixelRatio || 1;
+    const canvasWidth = this.canvas.width / ratio;
+    const canvasHeight = this.canvas.height / ratio;
+    const isoHeight = (this.room.width + this.room.height) * (this.tileHeight / 2);
+    this.originX = canvasWidth / 2;
+    const verticalPadding = Math.max(this.tileHeight, (canvasHeight - isoHeight) / 2);
+    this.originY = verticalPadding + this.tileHeight;
+  }
+
+  tileToScreen(x, y) {
+    const screenX = (x - y) * (this.tileWidth / 2) + this.originX;
+    const screenY = (x + y) * (this.tileHeight / 2) + this.originY;
+    return { x: screenX, y: screenY };
+  }
+
+  screenToTile(screenX, screenY) {
+    const dx = screenX - this.originX;
+    const dy = screenY - this.originY;
+    const isoX = dx / (this.tileWidth / 2);
+    const isoY = dy / (this.tileHeight / 2);
+    const gridX = (isoY + isoX) / 2;
+    const gridY = (isoY - isoX) / 2;
+    return { x: gridX, y: gridY };
+  }
+
+  pickTile(screenX, screenY) {
+    const fractional = this.screenToTile(screenX, screenY);
+    const baseX = Math.floor(fractional.x);
+    const baseY = Math.floor(fractional.y);
+    const candidates = [
+      { x: Math.round(fractional.x), y: Math.round(fractional.y) },
+      { x: baseX, y: baseY },
+      { x: baseX + 1, y: baseY },
+      { x: baseX, y: baseY + 1 },
+      { x: baseX + 1, y: baseY + 1 },
+      { x: baseX - 1, y: baseY },
+      { x: baseX, y: baseY - 1 },
+      { x: baseX - 1, y: baseY + 1 },
+      { x: baseX + 1, y: baseY - 1 },
+    ];
+
+    const seen = new Set();
+    for (const candidate of candidates) {
+      const key = `${candidate.x},${candidate.y}`;
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      if (!this.room.inBounds(candidate.x, candidate.y)) {
+        continue;
+      }
+      if (this.isPointInsideTile(screenX, screenY, candidate.x, candidate.y)) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  isPointInsideTile(screenX, screenY, tileX, tileY) {
+    const center = this.tileToScreen(tileX, tileY);
+    const dx = Math.abs(screenX - center.x) / (this.tileWidth / 2);
+    const dy = Math.abs(screenY - center.y) / (this.tileHeight / 2);
+    return dx + dy <= 1;
+  }
+
+  render() {
+    const ratio = this.pixelRatio || 1;
+    const width = this.canvas.width / ratio;
+    const height = this.canvas.height / ratio;
+    this.ctx.clearRect(0, 0, width, height);
+
+    this.drawFloor();
+    if (this.showGrid) {
+      this.drawGrid();
+    }
+    this.drawItems();
+    this.drawHover();
+  }
+
+  drawFloor() {
+    for (let y = 0; y < this.room.height; y += 1) {
+      for (let x = 0; x < this.room.width; x += 1) {
+        const type = this.room.getFloor(x, y);
+        const definition = this.floorDefinitions[type] ?? DEFAULT_FLOOR;
+        const position = this.tileToScreen(x, y);
+        this.drawDiamond(position.x, position.y, {
+          fill: definition.color,
+          stroke: definition.stroke ?? 'rgba(0, 0, 0, 0.35)',
+        });
+      }
+    }
+  }
+
+  drawGrid() {
+    this.ctx.save();
+    this.ctx.lineWidth = 1;
+    this.ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)';
+    for (let y = 0; y < this.room.height; y += 1) {
+      for (let x = 0; x < this.room.width; x += 1) {
+        const position = this.tileToScreen(x, y);
+        this.drawDiamond(position.x, position.y, { strokeOnly: true });
+      }
+    }
+    this.ctx.restore();
+  }
+
+  drawItems() {
+    for (const item of this.room.items) {
+      const definition = this.itemDefinitions[item.type] ?? DEFAULT_ITEM;
+      const position = this.tileToScreen(item.x, item.y);
+      this.drawPrism(position.x, position.y, definition);
+    }
+  }
+
+  drawHover() {
+    if (!this.hoverTile || !this.room.inBounds(this.hoverTile.x, this.hoverTile.y)) {
+      return;
+    }
+    const position = this.tileToScreen(this.hoverTile.x, this.hoverTile.y);
+    this.ctx.save();
+    this.ctx.globalAlpha = 0.6;
+    this.drawDiamond(position.x, position.y, {
+      fill: 'rgba(255, 236, 179, 0.6)',
+      stroke: 'rgba(255, 236, 179, 0.9)',
+    });
+    this.ctx.restore();
+  }
+
+  drawDiamond(x, y, { fill, stroke, strokeOnly = false } = {}) {
+    const ctx = this.ctx;
+    ctx.beginPath();
+    ctx.moveTo(x, y - this.tileHeight / 2);
+    ctx.lineTo(x + this.tileWidth / 2, y);
+    ctx.lineTo(x, y + this.tileHeight / 2);
+    ctx.lineTo(x - this.tileWidth / 2, y);
+    ctx.closePath();
+
+    if (fill && !strokeOnly) {
+      ctx.fillStyle = fill;
+      ctx.fill();
+    }
+    if (stroke || strokeOnly) {
+      ctx.strokeStyle = stroke ?? ctx.strokeStyle;
+      ctx.stroke();
+    }
+  }
+
+  drawPrism(x, y, definition) {
+    const ctx = this.ctx;
+    const height = definition.height ?? DEFAULT_ITEM.height;
+    const baseColor = definition.color ?? DEFAULT_ITEM.color;
+    const sideColor = adjustColor(baseColor, -35);
+    const topColor = adjustColor(baseColor, 20);
+
+    const topY = y - this.tileHeight / 2 - height;
+    const bottomY = y - this.tileHeight / 2;
+
+    ctx.save();
+    ctx.globalAlpha = 0.25;
+    this.drawDiamond(x, bottomY + this.tileHeight * 0.35, {
+      fill: 'rgba(0, 0, 0, 0.55)',
+    });
+    ctx.restore();
+
+    // top face
+    ctx.beginPath();
+    ctx.moveTo(x, topY);
+    ctx.lineTo(x + this.tileWidth / 2, topY + this.tileHeight / 2);
+    ctx.lineTo(x, topY + this.tileHeight);
+    ctx.lineTo(x - this.tileWidth / 2, topY + this.tileHeight / 2);
+    ctx.closePath();
+    ctx.fillStyle = topColor;
+    ctx.fill();
+
+    // right face
+    ctx.beginPath();
+    ctx.moveTo(x + this.tileWidth / 2, topY + this.tileHeight / 2);
+    ctx.lineTo(x + this.tileWidth / 2, bottomY + this.tileHeight / 2);
+    ctx.lineTo(x, bottomY + this.tileHeight);
+    ctx.lineTo(x, topY + this.tileHeight);
+    ctx.closePath();
+    ctx.fillStyle = sideColor;
+    ctx.fill();
+
+    // left face
+    ctx.beginPath();
+    ctx.moveTo(x - this.tileWidth / 2, topY + this.tileHeight / 2);
+    ctx.lineTo(x - this.tileWidth / 2, bottomY + this.tileHeight / 2);
+    ctx.lineTo(x, bottomY + this.tileHeight);
+    ctx.lineTo(x, topY + this.tileHeight);
+    ctx.closePath();
+    ctx.fillStyle = adjustColor(baseColor, -50);
+    ctx.fill();
+
+    // base outline
+    ctx.beginPath();
+    ctx.moveTo(x, bottomY);
+    ctx.lineTo(x + this.tileWidth / 2, bottomY + this.tileHeight / 2);
+    ctx.lineTo(x, bottomY + this.tileHeight);
+    ctx.lineTo(x - this.tileWidth / 2, bottomY + this.tileHeight / 2);
+    ctx.closePath();
+    ctx.strokeStyle = 'rgba(0, 0, 0, 0.45)';
+    ctx.stroke();
+  }
+}

--- a/src/room.js
+++ b/src/room.js
@@ -1,0 +1,96 @@
+export class Room {
+  constructor(width, height, { defaultFloor = 'void' } = {}) {
+    this.width = width;
+    this.height = height;
+    this.defaultFloor = defaultFloor;
+    this.floor = Array.from({ length: height }, () =>
+      Array.from({ length: width }, () => defaultFloor)
+    );
+    this.items = [];
+  }
+
+  inBounds(x, y) {
+    return x >= 0 && x < this.width && y >= 0 && y < this.height;
+  }
+
+  getFloor(x, y) {
+    return this.inBounds(x, y) ? this.floor[y][x] : null;
+  }
+
+  setFloor(x, y, type) {
+    if (!this.inBounds(x, y)) {
+      return false;
+    }
+    this.floor[y][x] = type;
+    return true;
+  }
+
+  toggleFloor(x, y, type) {
+    if (!this.inBounds(x, y)) {
+      return false;
+    }
+    const current = this.floor[y][x];
+    this.floor[y][x] = current === type ? this.defaultFloor : type;
+    return true;
+  }
+
+  itemAt(x, y) {
+    return (
+      this.items.find((item) => item.x === x && item.y === y) ?? null
+    );
+  }
+
+  placeItem(x, y, definition) {
+    if (!this.inBounds(x, y) || !definition) {
+      return null;
+    }
+
+    const current = this.itemAt(x, y);
+    if (current) {
+      current.definition = definition;
+      current.type = definition.id;
+      return current;
+    }
+
+    const placed = {
+      id: `${definition.id}-${Date.now()}-${Math.floor(Math.random() * 1000)}`,
+      type: definition.id,
+      x,
+      y,
+      definition,
+    };
+    this.items.push(placed);
+    return placed;
+  }
+
+  removeItem(x, y) {
+    const index = this.items.findIndex((item) => item.x === x && item.y === y);
+    if (index >= 0) {
+      return this.items.splice(index, 1)[0];
+    }
+    return null;
+  }
+
+  clear() {
+    for (let y = 0; y < this.height; y += 1) {
+      for (let x = 0; x < this.width; x += 1) {
+        this.floor[y][x] = this.defaultFloor;
+      }
+    }
+    this.items = [];
+  }
+
+  serialize() {
+    return {
+      width: this.width,
+      height: this.height,
+      floor: this.floor.map((row) => [...row]),
+      items: this.items.map((item) => ({
+        id: item.id,
+        type: item.type,
+        x: item.x,
+        y: item.y,
+      })),
+    };
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,282 @@
+:root {
+  --bg-dark: #06121f;
+  --bg-medium: #111d35;
+  --bg-light: #192e54;
+  --accent: #ffb347;
+  --accent-strong: #ff8b5d;
+  --text-primary: #f5f5f5;
+  --text-muted: #a6b2c4;
+  --panel-border: #253a65;
+  --panel-shadow: rgba(9, 16, 30, 0.6);
+  --hover-color: rgba(255, 222, 89, 0.75);
+  --font-family: 'Trebuchet MS', 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-family);
+  color: var(--text-primary);
+  background: radial-gradient(circle at 20% 20%, #213d73, var(--bg-dark) 70%);
+  display: flex;
+  flex-direction: column;
+}
+
+.top-bar {
+  background: linear-gradient(135deg, #253a65, #16294d);
+  padding: 1.5rem 2rem;
+  box-shadow: 0 6px 18px var(--panel-shadow);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.brand h1 {
+  margin: 0;
+  font-size: 2rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brand .tagline {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.app {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr) 240px;
+  gap: 1.5rem;
+  padding: 1.5rem 2rem 2rem;
+}
+
+.sidebar,
+.inspector {
+  background: var(--bg-light);
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  padding: 1.25rem;
+  box-shadow: 0 12px 32px var(--panel-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.sidebar h2,
+.inspector h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--accent);
+}
+
+.palette {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.palette-group h3 {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.palette-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.palette-item {
+  background: rgba(11, 19, 34, 0.55);
+  border: 1px solid transparent;
+  border-radius: 12px;
+  color: var(--text-primary);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, border 0.15s ease, box-shadow 0.15s ease;
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.palette-item .swatch {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 6px;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+
+.palette-item .label {
+  white-space: nowrap;
+}
+
+.palette-item.active {
+  border-color: var(--accent-strong);
+  box-shadow: 0 0 0 2px rgba(255, 139, 93, 0.5);
+  transform: translateY(-2px);
+}
+
+.palette-item:hover {
+  transform: translateY(-2px);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.control-button {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  border: none;
+  color: #1d1320;
+  font-weight: 700;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(255, 139, 93, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.control-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(255, 139, 93, 0.45);
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.toggle input {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.stage {
+  position: relative;
+  background: linear-gradient(160deg, #0e1b2d, #05101b);
+  border-radius: 20px;
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 18px 40px var(--panel-shadow);
+  overflow: hidden;
+  min-height: 520px;
+}
+
+#room-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  image-rendering: pixelated;
+}
+
+.hud {
+  position: absolute;
+  left: 1.25rem;
+  bottom: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: rgba(15, 26, 42, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  backdrop-filter: blur(6px);
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.hud-line .value {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.inspector {
+  gap: 1rem;
+}
+
+.inspector-list {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.inspector-list dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.inspector-list dd {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.guide h3 {
+  margin: 1rem 0 0.5rem;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.guide ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.footer {
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 1200px) {
+  .app {
+    grid-template-columns: 240px minmax(0, 1fr);
+    grid-template-areas:
+      'sidebar stage'
+      'inspector inspector';
+    grid-auto-rows: auto;
+  }
+
+  .inspector {
+    grid-column: 1 / -1;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 900px) {
+  .app {
+    grid-template-columns: 1fr;
+    grid-template-areas: none;
+  }
+
+  .sidebar,
+  .inspector {
+    order: 1;
+  }
+
+  .stage {
+    order: 0;
+    min-height: 400px;
+  }
+}


### PR DESCRIPTION
## Summary
- create a retro-inspired layout with palette, canvas stage, and inspector panels for room building
- implement vanilla JavaScript modules for room state management, isometric rendering, and UI interactions
- apply stylized theming and documentation to explain how to run and extend the skeleton

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf7b5060ac8332b907a7aea3c74c32