### PR TITLE
Add animated avatar that walks to clicked tiles

### DIFF
--- a/src/game/Avatar.js
+++ b/src/game/Avatar.js
@@ -1,0 +1,174 @@
+export class Avatar {
+  constructor(state) {
+    this.state = state;
+
+    const startX = Math.floor(state.width / 2);
+    const startY = Math.floor(state.height / 2);
+
+    this.position = { x: startX, y: startY };
+    this.segmentStart = { ...this.position };
+    this.segmentEnd = null;
+    this.segmentOffset = 0;
+    this.path = [];
+
+    this.speed = 2.8; // tiles per second
+    this.walkFrequency = 2.2; // cycles per second
+    this.walkPhase = 0;
+    this.isMoving = false;
+    this.direction = 'south';
+  }
+
+  moveTo(x, y) {
+    const targetX = Math.round(x);
+    const targetY = Math.round(y);
+
+    if (!this.state.isInside(targetX, targetY)) {
+      return;
+    }
+
+    const startTileX = Math.round(this.position.x);
+    const startTileY = Math.round(this.position.y);
+
+    this.path = this.buildPath(startTileX, startTileY, targetX, targetY);
+    this.segmentStart = { x: this.position.x, y: this.position.y };
+    this.segmentOffset = 0;
+
+    if (this.path.length > 0) {
+      this.segmentEnd = this.path.shift();
+      this.isMoving = true;
+      this.updateDirectionFromSegment();
+      return;
+    }
+
+    const atTarget =
+      Math.abs(this.position.x - targetX) < 1e-3 && Math.abs(this.position.y - targetY) < 1e-3;
+
+    if (!atTarget) {
+      this.segmentEnd = { x: targetX, y: targetY };
+      this.isMoving = true;
+      this.updateDirectionFromSegment();
+    } else {
+      this.segmentEnd = null;
+      this.isMoving = false;
+    }
+  }
+
+  update(deltaSeconds) {
+    if (deltaSeconds <= 0) {
+      return;
+    }
+
+    let remaining = this.speed * deltaSeconds;
+
+    while (remaining > 0 && this.segmentEnd) {
+      const dx = this.segmentEnd.x - this.segmentStart.x;
+      const dy = this.segmentEnd.y - this.segmentStart.y;
+      const distance = Math.hypot(dx, dy);
+
+      if (distance < 1e-6) {
+        this.position = { x: this.segmentEnd.x, y: this.segmentEnd.y };
+        this.segmentStart = { ...this.segmentEnd };
+        this.segmentOffset = 0;
+        this.advanceSegment();
+        continue;
+      }
+
+      const available = distance - this.segmentOffset;
+
+      if (remaining >= available) {
+        this.segmentOffset = 0;
+        remaining -= available;
+        this.segmentStart = { ...this.segmentEnd };
+        this.position = { ...this.segmentEnd };
+        this.advanceSegment();
+      } else {
+        this.segmentOffset += remaining;
+        remaining = 0;
+        const t = this.segmentOffset / distance;
+        this.position = {
+          x: this.segmentStart.x + dx * t,
+          y: this.segmentStart.y + dy * t
+        };
+      }
+    }
+
+    if (!this.segmentEnd) {
+      this.position = { x: this.segmentStart.x, y: this.segmentStart.y };
+      this.isMoving = false;
+    } else {
+      this.isMoving = true;
+      const dx = this.segmentEnd.x - this.segmentStart.x;
+      const dy = this.segmentEnd.y - this.segmentStart.y;
+      if (Math.hypot(dx, dy) < 1e-6) {
+        this.updateDirectionFromSegment();
+      }
+    }
+
+    if (this.isMoving) {
+      this.walkPhase = (this.walkPhase + deltaSeconds * this.walkFrequency) % 1;
+    } else {
+      this.walkPhase = 0;
+    }
+  }
+
+  getVisualState() {
+    return {
+      position: { ...this.position },
+      direction: this.direction,
+      isMoving: this.isMoving,
+      walkPhase: this.walkPhase
+    };
+  }
+
+  advanceSegment() {
+    if (this.path.length > 0) {
+      this.segmentEnd = this.path.shift();
+      this.segmentOffset = 0;
+      this.updateDirectionFromSegment();
+    } else {
+      this.segmentEnd = null;
+      this.segmentOffset = 0;
+      this.isMoving = false;
+    }
+  }
+
+  updateDirectionFromSegment() {
+    if (!this.segmentEnd) {
+      return;
+    }
+
+    const dx = this.segmentEnd.x - this.segmentStart.x;
+    const dy = this.segmentEnd.y - this.segmentStart.y;
+
+    if (Math.abs(dx) >= Math.abs(dy)) {
+      if (Math.abs(dx) > 1e-6) {
+        this.direction = dx > 0 ? 'east' : 'west';
+      }
+    } else if (Math.abs(dy) > 1e-6) {
+      this.direction = dy > 0 ? 'south' : 'north';
+    }
+  }
+
+  buildPath(startX, startY, targetX, targetY) {
+    const path = [];
+
+    let currentX = startX;
+    let currentY = startY;
+
+    const dx = targetX - currentX;
+    const stepX = Math.sign(dx);
+    for (let i = 0; i < Math.abs(dx); i += 1) {
+      currentX += stepX;
+      path.push({ x: currentX, y: currentY });
+    }
+
+    const dy = targetY - currentY;
+    const stepY = Math.sign(dy);
+    for (let i = 0; i < Math.abs(dy); i += 1) {
+      currentY += stepY;
+      path.push({ x: currentX, y: currentY });
+    }
+
+    return path;
+  }
+}

--- a/src/game/InputController.js
+++ b/src/game/InputController.js
@@ -1,8 +1,9 @@
 export class InputController {
-  constructor(canvas, state, renderer) {
+  constructor(canvas, state, renderer, avatar = null) {
     this.canvas = canvas;
     this.state = state;
     this.renderer = renderer;
+    this.avatar = avatar;
 
     this.handlePointerMove = this.handlePointerMove.bind(this);
     this.handlePointerLeave = this.handlePointerLeave.bind(this);
@@ -58,10 +59,16 @@ export class InputController {
 
     if (event.shiftKey) {
       this.state.sampleFloor(tile.x, tile.y);
+      if (this.avatar) {
+        this.avatar.moveTo(tile.x, tile.y);
+      }
       return;
     }
 
     this.state.placeSelection(tile.x, tile.y);
+    if (this.avatar) {
+      this.avatar.moveTo(tile.x, tile.y);
+    }
   }
 
   handleContextMenu(event) {

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import { GameState } from './game/GameState.js';
 import { IsoRenderer } from './game/IsoRenderer.js';
 import { InputController } from './game/InputController.js';
+import { Avatar } from './game/Avatar.js';
 import { createPaletteView } from './ui/paletteView.js';
 import { findPaletteItem, rotationLabels } from './game/palette.js';
 
@@ -12,7 +13,9 @@ const tileIndicator = document.getElementById('tileIndicator');
 
 const state = new GameState(14, 14);
 const renderer = new IsoRenderer(canvas, state);
-const input = new InputController(canvas, state, renderer);
+const avatar = new Avatar(state);
+renderer.setAvatar(avatar);
+const input = new InputController(canvas, state, renderer, avatar);
 createPaletteView(paletteRoot, state);
 
 state.onChange(() => {
@@ -20,6 +23,23 @@ state.onChange(() => {
   updateRotationUI();
   updateTileIndicator();
 });
+
+let previousTime = null;
+function animationFrame(timestamp) {
+  if (previousTime === null) {
+    previousTime = timestamp;
+  }
+
+  const deltaSeconds = Math.min((timestamp - previousTime) / 1000, 0.25);
+  previousTime = timestamp;
+
+  avatar.update(deltaSeconds);
+  renderer.draw();
+
+  requestAnimationFrame(animationFrame);
+}
+
+requestAnimationFrame(animationFrame);
 
 if (rotateButton) {
   rotateButton.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- introduce an Avatar controller that computes tile paths and maintains walking animation state
- render the avatar with a multi-part walking cycle layered on top of the isometric scene
- hook the avatar into the input controller and animation loop so clicks send the character to the chosen tile

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68cf9bdbc234833291e67f9902d50887