### PR TITLE
Fix avatar right vector orientation

### DIFF
--- a/src/game/IsoRenderer.js
+++ b/src/game/IsoRenderer.js
@@ -445,7 +445,7 @@ export class IsoRenderer {
     const { position, facing, walkPhase, stride, bob, sway, lean } = avatarState;
     const forwardBase = this.directionVectors[facing % this.directionVectors.length] ?? this.directionVectors[1];
     const forward = normalizeVec(forwardBase);
-    const right = normalizeVec({ x: forward.y, y: -forward.x });
+    const right = normalizeVec({ x: -forward.y, y: forward.x });
 
     const baseX = screenX;
     const baseY = screenY + this.halfTileHeight;


### PR DESCRIPTION
## Summary
- rotate the avatar right-hand vector +90° relative to the forward direction
- ensure limb positioning and lighting calculations use the proper screen-space orientation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cfa4475680833288605f934291ed6a