### PR TITLE
Add zoom controls for isometric room

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,26 @@
           >
             Rotate (R)
           </button>
+          <div class="zoom-controls" role="group" aria-label="Canvas zoom controls">
+            <button
+              id="zoomOutButton"
+              class="action-button zoom-button"
+              type="button"
+              title="Zoom out"
+              aria-label="Zoom out"
+            >
+              &minus;
+            </button>
+            <button
+              id="zoomInButton"
+              class="action-button zoom-button"
+              type="button"
+              title="Zoom in"
+              aria-label="Zoom in"
+            >
+              +
+            </button>
+          </div>
           <span class="rotation-label" id="rotationLabel">Facing: North-East</span>
         </div>
       </header>

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,8 @@ import { Avatar } from './game/Avatar.js';
 const canvas = document.getElementById('gameCanvas');
 const paletteRoot = document.getElementById('paletteRoot');
 const rotateButton = document.getElementById('rotateButton');
+const zoomOutButton = document.getElementById('zoomOutButton');
+const zoomInButton = document.getElementById('zoomInButton');
 const rotationLabel = document.getElementById('rotationLabel');
 const tileIndicator = document.getElementById('tileIndicator');
 const modeToggleButton = document.getElementById('modeToggle');
@@ -18,11 +20,14 @@ const renderer = new IsoRenderer(canvas, state, avatar);
 const input = new InputController(canvas, state, renderer, avatar);
 createPaletteView(paletteRoot, state);
 
+const ZOOM_STEP = 0.2;
+
 state.onChange(() => {
   renderer.draw();
   updateRotationUI();
   updateTileIndicator();
   updateModeToggle();
+  updateZoomControls();
 });
 
 if (rotateButton) {
@@ -40,9 +45,24 @@ if (modeToggleButton) {
   });
 }
 
+if (zoomInButton) {
+  zoomInButton.addEventListener('click', () => {
+    renderer.zoomIn(ZOOM_STEP);
+    updateZoomControls();
+  });
+}
+
+if (zoomOutButton) {
+  zoomOutButton.addEventListener('click', () => {
+    renderer.zoomOut(ZOOM_STEP);
+    updateZoomControls();
+  });
+}
+
 updateRotationUI();
 updateTileIndicator();
 updateModeToggle();
+updateZoomControls();
 
 function updateRotationUI() {
   const isWalkMode = state.isWalkMode();
@@ -132,6 +152,16 @@ function updateModeToggle() {
 
   if (canvas) {
     canvas.classList.toggle('walk-mode', isWalkMode);
+  }
+}
+
+function updateZoomControls() {
+  if (zoomOutButton) {
+    zoomOutButton.disabled = !renderer.canZoomOut();
+  }
+
+  if (zoomInButton) {
+    zoomInButton.disabled = !renderer.canZoomIn();
   }
 }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -74,6 +74,7 @@ h2 {
   display: flex;
   align-items: center;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .action-button {
@@ -109,6 +110,24 @@ h2 {
 .mode-toggle:focus-visible {
   outline: 2px solid rgba(255, 255, 255, 0.65);
   outline-offset: 2px;
+}
+
+.zoom-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.zoom-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  min-width: 2.5rem;
+  padding: 0.55rem 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+  line-height: 1;
 }
 
 .action-button:disabled,


### PR DESCRIPTION
## Summary
- add zoom in/out controls to the header UI with styling so the buttons sit alongside existing actions
- teach the renderer how to scale tile dimensions and clamp zoom levels with helper methods that the buttons can call
- wire the buttons into the app bootstrap so zoom changes trigger redraws and button disabled states update appropriately

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfa8f6935883329e7dfc547748ad8e