### PR TITLE
Add zoom controls for room view

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,26 @@
       <main class="app-main">
         <section class="scene-panel">
           <canvas id="gameCanvas" width="960" height="640"></canvas>
+          <div class="zoom-controls" role="group" aria-label="Zoom controls">
+            <button
+              id="zoomInButton"
+              class="zoom-button"
+              type="button"
+              aria-label="Zoom in"
+              title="Zoom in"
+            >
+              <span aria-hidden="true">+</span>
+            </button>
+            <button
+              id="zoomOutButton"
+              class="zoom-button"
+              type="button"
+              aria-label="Zoom out"
+              title="Zoom out"
+            >
+              <span aria-hidden="true">−</span>
+            </button>
+          </div>
           <div class="tile-indicator" id="tileIndicator">Hover over the room to inspect tiles.</div>
         </section>
         <aside class="palette-panel">
@@ -59,6 +79,7 @@
               <li><span>Right click</span> Remove furniture from the hovered tile</li>
               <li><span>R / Shift + R</span> Rotate hovered furniture or cycle the selection (Shift reverses)</li>
               <li><span>Shift + click</span> Sample the hovered floor style</li>
+              <li><span>Zoom buttons</span> Use + and − to adjust your view of the room</li>
             </ul>
           </div>
         </aside>

--- a/src/game/IsoRenderer.js
+++ b/src/game/IsoRenderer.js
@@ -33,22 +33,17 @@ export class IsoRenderer {
     this.avatar = avatar;
     this.ctx = canvas.getContext('2d');
 
-    this.tileWidth = 64;
-    this.tileHeight = 32;
-    this.halfTileWidth = this.tileWidth / 2;
-    this.halfTileHeight = this.tileHeight / 2;
-    this.wallHeight = this.tileHeight * 3;
+    this.baseTileWidth = 64;
+    this.baseTileHeight = 32;
+    this.minZoom = 0.6;
+    this.maxZoom = 1.6;
+    this.zoomStep = 0.2;
+    this.zoom = 1;
+    this.updateTileMetrics();
 
     this.pixelRatio = window.devicePixelRatio || 1;
     this.displayWidth = canvas.clientWidth || canvas.width;
     this.displayHeight = canvas.clientHeight || canvas.height;
-
-    this.directionVectors = [
-      { x: this.halfTileWidth, y: -this.halfTileHeight },
-      { x: this.halfTileWidth, y: this.halfTileHeight },
-      { x: -this.halfTileWidth, y: this.halfTileHeight },
-      { x: -this.halfTileWidth, y: -this.halfTileHeight }
-    ];
 
     this.forceRedraw = true;
     this.lastTimestamp = performance.now();
@@ -63,6 +58,55 @@ export class IsoRenderer {
     this.renderLoop = this.renderLoop.bind(this);
     this.drawFrame();
     this.animationFrameId = requestAnimationFrame(this.renderLoop);
+  }
+
+  updateTileMetrics() {
+    this.tileWidth = this.baseTileWidth * this.zoom;
+    this.tileHeight = this.baseTileHeight * this.zoom;
+    this.halfTileWidth = this.tileWidth / 2;
+    this.halfTileHeight = this.tileHeight / 2;
+    this.wallHeight = this.tileHeight * 3;
+
+    this.directionVectors = [
+      { x: this.halfTileWidth, y: -this.halfTileHeight },
+      { x: this.halfTileWidth, y: this.halfTileHeight },
+      { x: -this.halfTileWidth, y: this.halfTileHeight },
+      { x: -this.halfTileWidth, y: -this.halfTileHeight }
+    ];
+  }
+
+  setZoom(zoom) {
+    const value = Number.isFinite(zoom) ? zoom : this.zoom;
+    const clamped = Math.min(this.maxZoom, Math.max(this.minZoom, value));
+    if (Math.abs(clamped - this.zoom) < 0.001) {
+      return false;
+    }
+
+    this.zoom = clamped;
+    this.updateTileMetrics();
+    this.forceRedraw = true;
+    this.emitZoomChange();
+    return true;
+  }
+
+  zoomIn(step = this.zoomStep) {
+    return this.setZoom(this.zoom + step);
+  }
+
+  zoomOut(step = this.zoomStep) {
+    return this.setZoom(this.zoom - step);
+  }
+
+  canZoomIn() {
+    return this.zoom < this.maxZoom - 0.001;
+  }
+
+  canZoomOut() {
+    return this.zoom > this.minZoom + 0.001;
+  }
+
+  getZoom() {
+    return this.zoom;
   }
 
   resizeCanvas() {
@@ -802,6 +846,17 @@ export class IsoRenderer {
     const dx = Math.abs(px - centerX);
     const dy = Math.abs(py - centerY);
     return dx / this.halfTileWidth + dy / this.halfTileHeight <= 1;
+  }
+
+  emitZoomChange() {
+    if (!this.canvas || typeof this.canvas.dispatchEvent !== 'function') {
+      return;
+    }
+
+    const event = new CustomEvent('iso-renderer-zoom-change', {
+      detail: { zoom: this.zoom }
+    });
+    this.canvas.dispatchEvent(event);
   }
 
   destroy() {

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,8 @@ const rotateButton = document.getElementById('rotateButton');
 const rotationLabel = document.getElementById('rotationLabel');
 const tileIndicator = document.getElementById('tileIndicator');
 const modeToggleButton = document.getElementById('modeToggle');
+const zoomInButton = document.getElementById('zoomInButton');
+const zoomOutButton = document.getElementById('zoomOutButton');
 
 const state = new GameState(14, 14);
 const avatar = new Avatar(state);
@@ -40,9 +42,26 @@ if (modeToggleButton) {
   });
 }
 
+if (zoomInButton) {
+  zoomInButton.addEventListener('click', () => {
+    renderer.zoomIn();
+  });
+}
+
+if (zoomOutButton) {
+  zoomOutButton.addEventListener('click', () => {
+    renderer.zoomOut();
+  });
+}
+
+if (canvas) {
+  canvas.addEventListener('iso-renderer-zoom-change', updateZoomControls);
+}
+
 updateRotationUI();
 updateTileIndicator();
 updateModeToggle();
+updateZoomControls();
 
 function updateRotationUI() {
   const isWalkMode = state.isWalkMode();
@@ -133,6 +152,24 @@ function updateModeToggle() {
   if (canvas) {
     canvas.classList.toggle('walk-mode', isWalkMode);
   }
+}
+
+function updateZoomControls(event) {
+  if (!zoomInButton || !zoomOutButton) {
+    return;
+  }
+
+  const zoomLevel = typeof event?.detail?.zoom === 'number' ? event.detail.zoom : renderer.getZoom();
+  const zoomPercent = Math.round(zoomLevel * 100);
+
+  zoomInButton.disabled = !renderer.canZoomIn();
+  zoomOutButton.disabled = !renderer.canZoomOut();
+
+  const zoomLabel = `current zoom ${zoomPercent}%`;
+  zoomInButton.title = `Zoom in — ${zoomPercent}%`;
+  zoomOutButton.title = `Zoom out — ${zoomPercent}%`;
+  zoomInButton.setAttribute('aria-label', `Zoom in (${zoomLabel})`);
+  zoomOutButton.setAttribute('aria-label', `Zoom out (${zoomLabel})`);
 }
 
 window.addEventListener('beforeunload', () => {

--- a/styles/main.css
+++ b/styles/main.css
@@ -172,6 +172,62 @@ h2 {
   max-width: min(360px, 80%);
 }
 
+.zoom-controls {
+  position: absolute;
+  right: 2rem;
+  bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background: rgba(7, 9, 24, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 12px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(6px);
+}
+
+.zoom-button {
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 10px;
+  font-size: 1.4rem;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--text-primary);
+  background: linear-gradient(135deg, rgba(120, 240, 255, 0.72), rgba(107, 132, 255, 0.85));
+  box-shadow: 0 6px 16px rgba(86, 109, 255, 0.28);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  user-select: none;
+}
+
+.zoom-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(86, 109, 255, 0.32);
+}
+
+.zoom-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 2px;
+}
+
+.zoom-button:disabled,
+.zoom-button:disabled:hover {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.zoom-button span {
+  pointer-events: none;
+}
+
 .palette-panel {
   background: var(--panel-bg);
   border-radius: 16px;


### PR DESCRIPTION
## Summary
- add plus and minus zoom controls to the scene overlay and mention them in the controls legend
- style the new zoom buttons to match the retro UI
- extend the renderer with zoom support and wire the buttons to adjust the view and accessibility labels

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68cfa8f6935883329e7dfc547748ad8e