### PR TITLE
Add zoom controls for room view

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,27 @@
           >
             Walk Mode: Off
           </button>
+          <div class="zoom-controls" role="group" aria-label="Zoom level controls">
+            <button
+              id="zoomOut"
+              class="action-button zoom-button"
+              type="button"
+              title="Zoom out"
+              aria-label="Zoom out"
+            >
+              &minus;
+            </button>
+            <span class="zoom-label" id="zoomLevel" aria-live="polite">100%</span>
+            <button
+              id="zoomIn"
+              class="action-button zoom-button"
+              type="button"
+              title="Zoom in"
+              aria-label="Zoom in"
+            >
+              +
+            </button>
+          </div>
           <button
             id="rotateButton"
             class="action-button"

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,9 @@ const rotateButton = document.getElementById('rotateButton');
 const rotationLabel = document.getElementById('rotationLabel');
 const tileIndicator = document.getElementById('tileIndicator');
 const modeToggleButton = document.getElementById('modeToggle');
+const zoomInButton = document.getElementById('zoomIn');
+const zoomOutButton = document.getElementById('zoomOut');
+const zoomLevelLabel = document.getElementById('zoomLevel');
 
 const state = new GameState(14, 14);
 const avatar = new Avatar(state);
@@ -40,9 +43,24 @@ if (modeToggleButton) {
   });
 }
 
+if (zoomInButton) {
+  zoomInButton.addEventListener('click', () => {
+    renderer.zoomIn();
+    updateZoomUI();
+  });
+}
+
+if (zoomOutButton) {
+  zoomOutButton.addEventListener('click', () => {
+    renderer.zoomOut();
+    updateZoomUI();
+  });
+}
+
 updateRotationUI();
 updateTileIndicator();
 updateModeToggle();
+updateZoomUI();
 
 function updateRotationUI() {
   const isWalkMode = state.isWalkMode();
@@ -132,6 +150,21 @@ function updateModeToggle() {
 
   if (canvas) {
     canvas.classList.toggle('walk-mode', isWalkMode);
+  }
+}
+
+function updateZoomUI() {
+  if (zoomLevelLabel) {
+    const zoomPercent = Math.round(renderer.getZoomLevel() * 100);
+    zoomLevelLabel.textContent = `${zoomPercent}%`;
+  }
+
+  if (zoomInButton) {
+    zoomInButton.disabled = !renderer.canZoomIn();
+  }
+
+  if (zoomOutButton) {
+    zoomOutButton.disabled = !renderer.canZoomOut();
   }
 }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -76,6 +76,37 @@ h2 {
   gap: 1rem;
 }
 
+.zoom-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.6rem;
+  background: rgba(14, 18, 40, 0.6);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.zoom-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  min-width: 3ch;
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+
+.action-button.zoom-button {
+  width: 2.35rem;
+  height: 2.35rem;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
 .action-button {
   padding: 0.65rem 1.1rem;
   border-radius: 10px;


### PR DESCRIPTION
## Summary
- add zoom in/out controls to the header UI with visual styling and labels
- extend the isometric renderer with adjustable zoom handling and helper APIs for UI
- update the main entry to wire zoom buttons into the renderer and reflect the active zoom level

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfa8f6935883329e7dfc547748ad8e