### PR TITLE
Add interactive furniture studio for palette customization

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,13 @@
             Pick a floor style or furnish the space. Left click to place, right click to remove furniture. Switch to walk mode to send the avatar exploring.
           </p>
           <div id="paletteRoot" class="palette-root"></div>
+          <section class="studio-panel" aria-labelledby="furnitureStudioHeading">
+            <h2 id="furnitureStudioHeading">Furniture Studio</h2>
+            <p class="panel-description">
+              Tweak the colors, shapes, and heights of existing pieces or craft a brand-new furniture design for your suite.
+            </p>
+            <div id="furnitureStudio"></div>
+          </section>
           <div class="legend">
             <h3>Controls</h3>
             <ul>

--- a/src/game/IsoRenderer.js
+++ b/src/game/IsoRenderer.js
@@ -411,6 +411,9 @@ export class IsoRenderer {
       case 'palm-plant':
         this.drawPalmPlant(ctx, sx, sy, definition, rotation);
         break;
+      case 'block':
+        this.drawFurnitureBlock(ctx, sx, sy, definition, rotation);
+        break;
       default:
         this.drawFurnitureBlock(ctx, sx, sy, definition, rotation);
         break;

--- a/src/game/palette.js
+++ b/src/game/palette.js
@@ -1,4 +1,4 @@
-export const palette = {
+const basePalette = {
   floor: [
     {
       id: 'sunset-parquet',
@@ -61,6 +61,41 @@ export const palette = {
   ]
 };
 
+export const furnitureShapes = [
+  {
+    id: 'retro-sofa',
+    label: 'Retro sofa',
+    description: 'Rounded loveseat with back cushions and a cozy seat.'
+  },
+  {
+    id: 'lofi-table',
+    label: 'Lofi table',
+    description: 'Low wooden coffee table with a gentle taper.'
+  },
+  {
+    id: 'neon-lamp',
+    label: 'Neon lamp',
+    description: 'Tall glowing column that casts ambient light.'
+  },
+  {
+    id: 'palm-plant',
+    label: 'Palm plant',
+    description: 'Leafy palm with a slender base and big fronds.'
+  },
+  {
+    id: 'block',
+    label: 'Simple block',
+    description: 'Generic block with an orientation indicator on top.'
+  }
+];
+
+export const palette = {
+  floor: basePalette.floor.map((item) => ({ ...item })),
+  furniture: basePalette.furniture.map((item) => ({ ...item }))
+};
+
+const paletteListeners = new Set();
+
 export const rotationLabels = ['North-East', 'South-East', 'South-West', 'North-West'];
 
 export function findPaletteItem(category, id) {
@@ -73,4 +108,131 @@ export function findPaletteItem(category, id) {
 
 export function getDefaultSelection() {
   return { category: 'floor', itemId: palette.floor[0].id };
+}
+
+export function onPaletteChange(listener) {
+  if (typeof listener !== 'function') {
+    return () => {};
+  }
+
+  paletteListeners.add(listener);
+  return () => {
+    paletteListeners.delete(listener);
+  };
+}
+
+export function getPaletteSnapshot() {
+  return {
+    floor: palette.floor.map((item) => ({ ...item })),
+    furniture: palette.furniture.map((item) => ({ ...item }))
+  };
+}
+
+export function addFurnitureDefinition(definition) {
+  const sanitized = sanitizeFurnitureDefinition(definition, { allowExistingId: false });
+  const proposedId = definition?.id ?? definition?.name;
+  const baseId = createSlug(proposedId);
+  const uniqueId = ensureUniqueFurnitureId(baseId);
+  const entry = { ...sanitized, id: uniqueId };
+  palette.furniture.push(entry);
+  notifyPaletteListeners();
+  return entry;
+}
+
+export function updateFurnitureDefinition(id, updates) {
+  if (!id) {
+    return null;
+  }
+
+  const index = palette.furniture.findIndex((item) => item.id === id);
+  if (index === -1) {
+    return null;
+  }
+
+  const sanitized = sanitizeFurnitureDefinition({ ...palette.furniture[index], ...updates, id }, {
+    allowExistingId: true
+  });
+
+  palette.furniture[index] = sanitized;
+  notifyPaletteListeners();
+  return sanitized;
+}
+
+function sanitizeFurnitureDefinition(definition, { allowExistingId }) {
+  const fallbackColor = '#cccccc';
+  const defaultHeight = 48;
+  const safeDefinition = typeof definition === 'object' && definition !== null ? definition : {};
+
+  const name = typeof safeDefinition.name === 'string' ? safeDefinition.name.trim() : '';
+  const description = typeof safeDefinition.description === 'string' ? safeDefinition.description.trim() : '';
+  const colorInput = typeof safeDefinition.color === 'string' ? safeDefinition.color.trim() : '';
+  const color = /^#([0-9a-f]{6})$/i.test(colorInput) ? `#${colorInput.slice(1).toLowerCase()}` : fallbackColor;
+  const heightValue = Number.parseFloat(safeDefinition.height);
+  const height = Number.isFinite(heightValue)
+    ? Math.max(8, Math.min(160, Math.round(heightValue)))
+    : defaultHeight;
+  const shapeInput = typeof safeDefinition.shape === 'string' ? safeDefinition.shape.trim() : '';
+  const allowedShapes = new Set(furnitureShapes.map((shape) => shape.id));
+  const shape = allowedShapes.has(shapeInput) ? shapeInput : 'block';
+
+  const entry = {
+    name: name || 'Untitled furniture',
+    description,
+    color,
+    height,
+    shape
+  };
+
+  if (allowExistingId && typeof safeDefinition.id === 'string' && safeDefinition.id.trim()) {
+    entry.id = safeDefinition.id.trim();
+  }
+
+  return entry;
+}
+
+function createSlug(source) {
+  const fallback = 'custom-piece';
+  if (!source || typeof source !== 'string') {
+    return fallback;
+  }
+
+  const normalized = source
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+
+  if (!normalized) {
+    return fallback;
+  }
+
+  return normalized.slice(0, 48);
+}
+
+function ensureUniqueFurnitureId(baseId) {
+  const fallback = 'custom-piece';
+  const sanitizedBase = baseId && typeof baseId === 'string' ? baseId : fallback;
+  const existingIds = new Set(palette.furniture.map((item) => item.id));
+
+  if (!existingIds.has(sanitizedBase)) {
+    return sanitizedBase;
+  }
+
+  let suffix = 2;
+  while (existingIds.has(`${sanitizedBase}-${suffix}`)) {
+    suffix += 1;
+  }
+
+  return `${sanitizedBase}-${suffix}`;
+}
+
+function notifyPaletteListeners() {
+  const snapshot = getPaletteSnapshot();
+  paletteListeners.forEach((listener) => {
+    try {
+      listener(snapshot);
+    } catch (error) {
+      console.error('Palette listener error', error);
+    }
+  });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import { GameState } from './game/GameState.js';
 import { IsoRenderer } from './game/IsoRenderer.js';
 import { InputController } from './game/InputController.js';
 import { createPaletteView } from './ui/paletteView.js';
+import { createFurnitureStudio } from './ui/furnitureStudio.js';
 import { findPaletteItem, rotationLabels } from './game/palette.js';
 import { Avatar } from './game/Avatar.js';
 
@@ -13,12 +14,14 @@ const tileIndicator = document.getElementById('tileIndicator');
 const modeToggleButton = document.getElementById('modeToggle');
 const zoomInButton = document.getElementById('zoomInButton');
 const zoomOutButton = document.getElementById('zoomOutButton');
+const furnitureStudioRoot = document.getElementById('furnitureStudio');
 
 const state = new GameState(14, 14);
 const avatar = new Avatar(state);
 const renderer = new IsoRenderer(canvas, state, avatar);
 const input = new InputController(canvas, state, renderer, avatar);
 createPaletteView(paletteRoot, state);
+createFurnitureStudio(furnitureStudioRoot, state);
 
 state.onChange(() => {
   renderer.draw();

--- a/src/ui/furnitureStudio.js
+++ b/src/ui/furnitureStudio.js
@@ -1,0 +1,374 @@
+import {
+  palette,
+  furnitureShapes,
+  addFurnitureDefinition,
+  updateFurnitureDefinition,
+  onPaletteChange,
+  findPaletteItem
+} from '../game/palette.js';
+
+const DEFAULT_NEW_PIECE = {
+  name: 'Custom Lounge Seat',
+  description: 'Dream up a fresh piece and drop it into your suite.',
+  color: '#c9c3ff',
+  height: 48,
+  shape: 'block'
+};
+
+const HEX_COLOR_PATTERN = /^#([0-9a-f]{6})$/i;
+
+export function createFurnitureStudio(root, state) {
+  if (!root) {
+    return null;
+  }
+
+  root.classList.add('furniture-studio');
+
+  const shapeOptions = furnitureShapes
+    .map(({ id, label }) => `<option value="${id}">${label}</option>`)
+    .join('');
+
+  root.innerHTML = `
+    <div class="studio-toolbar">
+      <label class="studio-select-field">
+        <span class="studio-label">Edit existing piece</span>
+        <select class="studio-select" data-role="existing-select"></select>
+      </label>
+      <button type="button" class="studio-secondary studio-new" data-role="new-button">Start from blank</button>
+    </div>
+    <form class="studio-form" novalidate>
+      <div class="studio-meta" data-role="mode-label">Editing existing piece</div>
+      <div class="studio-meta-id" data-role="current-id">ID: —</div>
+      <div class="studio-field">
+        <label class="studio-field-label">
+          <span class="studio-label">Furniture name</span>
+          <input type="text" maxlength="48" class="studio-input" data-role="name" required />
+        </label>
+      </div>
+      <div class="studio-field">
+        <label class="studio-field-label">
+          <span class="studio-label">Description</span>
+          <textarea class="studio-input studio-textarea" rows="3" data-role="description"></textarea>
+        </label>
+      </div>
+      <div class="studio-field studio-color-field">
+        <span class="studio-label">Color</span>
+        <div class="studio-color-controls">
+          <input type="color" class="studio-color-picker" data-role="color-picker" aria-label="Pick furniture color" />
+          <input
+            type="text"
+            class="studio-input studio-color-hex"
+            data-role="color-hex"
+            maxlength="7"
+            placeholder="#aabbcc"
+            aria-label="Hex color"
+          />
+        </div>
+      </div>
+      <div class="studio-field studio-height-field">
+        <label class="studio-field-label">
+          <span class="studio-label">Height</span>
+          <input
+            type="number"
+            min="8"
+            max="160"
+            step="1"
+            class="studio-input"
+            data-role="height"
+            required
+          />
+        </label>
+        <div class="studio-meter" data-role="height-value">48 px tall</div>
+      </div>
+      <div class="studio-field studio-shape-field">
+        <label class="studio-field-label">
+          <span class="studio-label">Shape preset</span>
+          <select class="studio-select" data-role="shape">${shapeOptions}</select>
+        </label>
+        <p class="studio-hint" data-role="shape-hint"></p>
+      </div>
+      <div class="studio-actions">
+        <button type="submit" class="studio-primary" data-role="save">Save changes</button>
+        <button type="button" class="studio-secondary" data-role="add">Add to palette</button>
+      </div>
+    </form>
+    <p class="studio-help">
+      Tip: Use “Save changes” to update the selected piece or “Add to palette” to duplicate your tweaks as a brand new item.
+    </p>
+    <div class="studio-feedback" data-role="status" role="status" aria-live="polite"></div>
+  `;
+
+  const existingSelect = root.querySelector('[data-role="existing-select"]');
+  const newButton = root.querySelector('[data-role="new-button"]');
+  const modeLabel = root.querySelector('[data-role="mode-label"]');
+  const idLabel = root.querySelector('[data-role="current-id"]');
+  const nameInput = root.querySelector('[data-role="name"]');
+  const descriptionInput = root.querySelector('[data-role="description"]');
+  const colorPicker = root.querySelector('[data-role="color-picker"]');
+  const colorHexInput = root.querySelector('[data-role="color-hex"]');
+  const heightInput = root.querySelector('[data-role="height"]');
+  const heightValue = root.querySelector('[data-role="height-value"]');
+  const shapeSelect = root.querySelector('[data-role="shape"]');
+  const shapeHint = root.querySelector('[data-role="shape-hint"]');
+  const saveButton = root.querySelector('[data-role="save"]');
+  const addButton = root.querySelector('[data-role="add"]');
+  const statusArea = root.querySelector('[data-role="status"]');
+
+  const shapesById = new Map(furnitureShapes.map((shape) => [shape.id, shape]));
+
+  let editingId = null;
+  updateSelectOptions();
+
+  if (palette.furniture.length > 0) {
+    loadExistingDefinition(palette.furniture[0].id);
+  } else {
+    switchToNew(DEFAULT_NEW_PIECE);
+  }
+
+  existingSelect.addEventListener('change', () => {
+    const selectedId = existingSelect.value;
+    if (!selectedId) {
+      switchToNew(DEFAULT_NEW_PIECE);
+      return;
+    }
+
+    loadExistingDefinition(selectedId);
+  });
+
+  newButton.addEventListener('click', () => {
+    switchToNew({ ...DEFAULT_NEW_PIECE, name: suggestUniqueName() });
+    existingSelect.value = '';
+  });
+
+  heightInput.addEventListener('input', () => {
+    const value = normalizeHeight(heightInput.value);
+    heightValue.textContent = `${value} px tall`;
+  });
+
+  shapeSelect.addEventListener('change', updateShapeHint);
+
+  colorPicker.addEventListener('input', () => {
+    const normalized = toValidColor(colorPicker.value);
+    colorPicker.value = normalized;
+    colorHexInput.value = normalized.toUpperCase();
+  });
+
+  colorHexInput.addEventListener('input', () => {
+    const normalized = tryParseColor(colorHexInput.value);
+    if (normalized) {
+      colorPicker.value = normalized;
+      colorHexInput.value = normalized.toUpperCase();
+    }
+  });
+
+  colorHexInput.addEventListener('blur', () => {
+    const normalized = tryParseColor(colorHexInput.value) ?? toValidColor(colorPicker.value);
+    colorPicker.value = normalized;
+    colorHexInput.value = normalized.toUpperCase();
+  });
+
+  const form = root.querySelector('.studio-form');
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    handleSave();
+  });
+
+  addButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    handleAdd();
+  });
+
+  const unsubscribePalette = onPaletteChange(() => {
+    updateSelectOptions();
+    if (editingId) {
+      const current = findPaletteItem('furniture', editingId);
+      if (current) {
+        fillForm(current);
+      }
+    }
+  });
+
+  updateShapeHint();
+
+  return {
+    destroy() {
+      unsubscribePalette();
+    }
+  };
+
+  function handleSave() {
+    if (!editingId) {
+      setStatus('Select a furniture piece to update, or add it as a new entry instead.', 'warning');
+      return;
+    }
+
+    const payload = collectFormValues();
+    const updated = updateFurnitureDefinition(editingId, payload);
+    if (!updated) {
+      setStatus('Something went wrong while saving your changes.', 'error');
+      return;
+    }
+
+    setStatus(`Saved updates to “${updated.name}”.`, 'success');
+    state?.setSelection?.('furniture', updated.id);
+    fillForm(updated);
+    updateSelectOptions();
+    existingSelect.value = updated.id;
+  }
+
+  function handleAdd() {
+    const payload = collectFormValues();
+    const created = addFurnitureDefinition(payload);
+    if (!created) {
+      setStatus('Unable to add the furniture to the palette.', 'error');
+      return;
+    }
+
+    setStatus(`Added “${created.name}” to the palette.`, 'success');
+    editingId = created.id;
+    state?.setSelection?.('furniture', created.id);
+    fillForm(created);
+    updateSelectOptions();
+    existingSelect.value = created.id;
+    modeLabel.textContent = 'Editing existing piece';
+    idLabel.textContent = `ID: ${created.id}`;
+    saveButton.disabled = false;
+  }
+
+  function collectFormValues() {
+    return {
+      name: nameInput.value.trim() || DEFAULT_NEW_PIECE.name,
+      description: descriptionInput.value.trim(),
+      color: tryParseColor(colorHexInput.value) ?? toValidColor(colorPicker.value),
+      height: normalizeHeight(heightInput.value),
+      shape: shapeSelect.value
+    };
+  }
+
+  function loadExistingDefinition(id) {
+    const definition = findPaletteItem('furniture', id);
+    if (!definition) {
+      switchToNew(DEFAULT_NEW_PIECE);
+      return;
+    }
+
+    editingId = id;
+    modeLabel.textContent = 'Editing existing piece';
+    idLabel.textContent = `ID: ${definition.id}`;
+    fillForm(definition);
+    existingSelect.value = definition.id;
+    saveButton.disabled = false;
+    setStatus('Editing an existing piece. Save to apply your adjustments.', 'info');
+  }
+
+  function switchToNew(template) {
+    editingId = null;
+    modeLabel.textContent = 'Designing a new piece';
+    idLabel.textContent = 'ID: (new)';
+    fillForm(template);
+    saveButton.disabled = true;
+    existingSelect.value = '';
+    setStatus('Designing a fresh piece. Use “Add to palette” to store it.', 'info');
+  }
+
+  function fillForm(definition) {
+    const color = toValidColor(definition?.color);
+    nameInput.value = definition?.name ?? DEFAULT_NEW_PIECE.name;
+    descriptionInput.value = definition?.description ?? '';
+    colorPicker.value = color;
+    colorHexInput.value = color.toUpperCase();
+    const height = normalizeHeight(definition?.height);
+    heightInput.value = height;
+    heightValue.textContent = `${height} px tall`;
+    shapeSelect.value = definition?.shape && shapesById.has(definition.shape)
+      ? definition.shape
+      : DEFAULT_NEW_PIECE.shape;
+    updateShapeHint();
+  }
+
+  function updateSelectOptions() {
+    const previouslySelected = existingSelect.value;
+
+    existingSelect.innerHTML = '';
+    const newOption = document.createElement('option');
+    newOption.value = '';
+    newOption.textContent = 'Create new furniture';
+    existingSelect.appendChild(newOption);
+
+    palette.furniture.forEach((item) => {
+      const option = document.createElement('option');
+      option.value = item.id;
+      option.textContent = item.name;
+      existingSelect.appendChild(option);
+    });
+
+    if (editingId) {
+      existingSelect.value = editingId;
+    } else if (previouslySelected === '') {
+      existingSelect.value = '';
+    }
+  }
+
+  function updateShapeHint() {
+    const selected = shapesById.get(shapeSelect.value);
+    shapeHint.textContent = selected?.description ?? '';
+  }
+
+  function setStatus(message, variant = 'info') {
+    statusArea.textContent = message;
+    statusArea.classList.remove('is-success', 'is-error', 'is-warning');
+    if (variant === 'success') {
+      statusArea.classList.add('is-success');
+    } else if (variant === 'error') {
+      statusArea.classList.add('is-error');
+    } else if (variant === 'warning') {
+      statusArea.classList.add('is-warning');
+    }
+  }
+
+  function normalizeHeight(value) {
+    const numeric = Number.parseFloat(value);
+    if (!Number.isFinite(numeric)) {
+      return DEFAULT_NEW_PIECE.height;
+    }
+
+    return Math.max(8, Math.min(160, Math.round(numeric)));
+  }
+
+  function tryParseColor(value) {
+    if (typeof value !== 'string') {
+      return null;
+    }
+
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const formatted = trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+    if (HEX_COLOR_PATTERN.test(formatted)) {
+      return formatted.slice(0, 7).toLowerCase();
+    }
+
+    return null;
+  }
+
+  function toValidColor(value, fallback = DEFAULT_NEW_PIECE.color) {
+    return tryParseColor(value) ?? fallback;
+  }
+
+  function suggestUniqueName() {
+    const base = 'Custom Piece';
+    const existingNames = new Set(palette.furniture.map((item) => item.name));
+    if (!existingNames.has(base)) {
+      return base;
+    }
+
+    let suffix = 2;
+    while (existingNames.has(`${base} ${suffix}`)) {
+      suffix += 1;
+    }
+
+    return `${base} ${suffix}`;
+  }
+}

--- a/src/ui/paletteView.js
+++ b/src/ui/paletteView.js
@@ -1,4 +1,4 @@
-import { palette } from '../game/palette.js';
+import { palette, onPaletteChange } from '../game/palette.js';
 
 export function createPaletteView(root, state) {
   if (!root) {
@@ -59,7 +59,7 @@ export function createPaletteView(root, state) {
   updateActiveStates();
   updateSelectionDetails();
 
-  const unsubscribe = state.onChange(() => {
+  const unsubscribeState = state.onChange(() => {
     if (state.selectedCategory !== currentCategory) {
       currentCategory = state.selectedCategory;
       renderItems(currentCategory);
@@ -69,9 +69,16 @@ export function createPaletteView(root, state) {
     updateSelectionDetails();
   });
 
+  const unsubscribePalette = onPaletteChange(() => {
+    renderItems(currentCategory);
+    updateActiveStates();
+    updateSelectionDetails();
+  });
+
   return {
     destroy() {
-      unsubscribe();
+      unsubscribeState();
+      unsubscribePalette();
     }
   };
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -372,6 +372,235 @@ h2 {
   line-height: 1.5;
 }
 
+.studio-panel {
+  background: rgba(15, 18, 42, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.studio-panel h2 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.furniture-studio {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.studio-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.8rem;
+}
+
+.studio-select-field {
+  flex: 1 1 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.studio-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 600;
+  color: rgba(243, 244, 255, 0.72);
+}
+
+.studio-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.studio-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.studio-field-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.studio-input,
+.studio-select,
+.studio-textarea {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(118, 136, 255, 0.2);
+  background: rgba(14, 18, 44, 0.88);
+  color: var(--text-primary);
+  font: inherit;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.studio-input:focus-visible,
+.studio-select:focus-visible,
+.studio-textarea:focus-visible {
+  outline: 2px solid rgba(255, 179, 71, 0.65);
+  outline-offset: 2px;
+  border-color: rgba(255, 179, 71, 0.8);
+  box-shadow: 0 0 0 3px rgba(255, 179, 71, 0.1);
+}
+
+.studio-textarea {
+  resize: vertical;
+  min-height: 84px;
+}
+
+.studio-color-controls {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.studio-color-picker {
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: transparent;
+  cursor: pointer;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.studio-color-picker::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.studio-color-picker::-webkit-color-swatch {
+  border-radius: 10px;
+  border: none;
+}
+
+.studio-color-picker::-moz-color-swatch {
+  border: none;
+  border-radius: 10px;
+}
+
+.studio-color-hex {
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+  text-transform: uppercase;
+}
+
+.studio-height-field {
+  gap: 0.3rem;
+}
+
+.studio-meter {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.studio-hint {
+  margin: 0;
+  font-size: 0.76rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.studio-meta,
+.studio-meta-id {
+  font-size: 0.78rem;
+  color: rgba(243, 244, 255, 0.7);
+}
+
+.studio-meta-id {
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+  letter-spacing: 0.04em;
+}
+
+.studio-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.studio-primary,
+.studio-secondary {
+  border-radius: 10px;
+  font-weight: 600;
+  padding: 0.65rem 1.05rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.studio-primary {
+  border: 0;
+  background: linear-gradient(135deg, #7fffd4, #64ddff 55%, #7f97ff);
+  color: #081436;
+  box-shadow: 0 8px 20px rgba(102, 198, 255, 0.28);
+}
+
+.studio-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(102, 198, 255, 0.32);
+}
+
+.studio-primary:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.studio-secondary {
+  border: 1px solid rgba(126, 142, 255, 0.32);
+  background: rgba(18, 22, 54, 0.85);
+  color: var(--text-primary);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.studio-secondary:hover {
+  transform: translateY(-1px);
+  border-color: rgba(182, 198, 255, 0.6);
+}
+
+.studio-secondary:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.studio-help {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+
+.studio-feedback {
+  min-height: 1.2rem;
+  font-size: 0.8rem;
+  color: rgba(243, 244, 255, 0.75);
+}
+
+.studio-feedback.is-success {
+  color: #7dffca;
+}
+
+.studio-feedback.is-error {
+  color: #ff8a9f;
+}
+
+.studio-feedback.is-warning {
+  color: #ffd890;
+}
+
 .legend {
   margin-top: auto;
   padding-top: 1rem;


### PR DESCRIPTION
## Summary
- add palette mutation helpers and shape metadata so furniture definitions can be updated at runtime
- introduce a furniture studio interface for creating and editing pieces, complete with styling and layout updates
- refresh supporting components so the palette responds to edits and the renderer handles the generic block preset

## Testing
- node --check src/ui/furnitureStudio.js
- node --check src/game/palette.js

------
https://chatgpt.com/codex/tasks/task_e_68d0dc11ccfc8332a525922a92dd741c