### PR TITLE
Add furniture studio for creating and editing pieces

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,15 @@
             Pick a floor style or furnish the space. Left click to place, right click to remove furniture. Switch to walk mode to send the avatar exploring.
           </p>
           <div id="paletteRoot" class="palette-root"></div>
+          <section class="studio-panel" aria-labelledby="furnitureStudioHeading">
+            <div class="studio-header">
+              <h3 id="furnitureStudioHeading">Furniture Studio</h3>
+              <p class="studio-subtitle">
+                Remix colour, height, and personality or mint a brand-new furnishing.
+              </p>
+            </div>
+            <div id="furnitureStudioRoot" class="studio-root"></div>
+          </section>
           <div class="legend">
             <h3>Controls</h3>
             <ul>

--- a/src/game/GameState.js
+++ b/src/game/GameState.js
@@ -218,4 +218,8 @@ export class GameState {
     this.selectedItemId = floorId;
     this.notifyChange();
   }
+
+  refresh() {
+    this.notifyChange();
+  }
 }

--- a/src/game/palette.js
+++ b/src/game/palette.js
@@ -63,6 +63,168 @@ export const palette = {
 
 export const rotationLabels = ['North-East', 'South-East', 'South-West', 'North-West'];
 
+const paletteListeners = new Set();
+
+export const furnitureShapeOptions = [
+  { id: 'retro-sofa', label: 'Retro sofa (seat + back)' },
+  { id: 'lofi-table', label: 'Low table' },
+  { id: 'neon-lamp', label: 'Neon lamp column' },
+  { id: 'palm-plant', label: 'Palm plant' },
+  { id: 'block', label: 'Simple block' }
+];
+
+export function onPaletteChange(listener) {
+  if (typeof listener !== 'function') {
+    return () => {};
+  }
+
+  paletteListeners.add(listener);
+  return () => paletteListeners.delete(listener);
+}
+
+function emitPaletteChange(detail) {
+  paletteListeners.forEach((listener) => {
+    try {
+      listener(detail);
+    } catch (error) {
+      // Swallow listener errors so one bad subscriber does not break updates.
+      console.error('Palette listener error', error);
+    }
+  });
+}
+
+function sanitizeHexColor(value, fallback = '#cccccc') {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  const sixDigitMatch = trimmed.match(/^#?([0-9a-fA-F]{6})$/);
+  if (sixDigitMatch) {
+    return `#${sixDigitMatch[1].toLowerCase()}`;
+  }
+
+  const threeDigitMatch = trimmed.match(/^#?([0-9a-fA-F]{3})$/);
+  if (threeDigitMatch) {
+    const expanded = threeDigitMatch[1]
+      .split('')
+      .map((char) => `${char}${char}`)
+      .join('');
+    return `#${expanded.toLowerCase()}`;
+  }
+
+  return fallback;
+}
+
+function clampHeight(value, fallback = 52) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return fallback;
+  }
+
+  const rounded = Math.round(numeric);
+  const min = 12;
+  const max = 160;
+  return Math.min(max, Math.max(min, rounded));
+}
+
+function isValidShape(shape) {
+  return furnitureShapeOptions.some((option) => option.id === shape);
+}
+
+function normalizeShape(shape, fallback = 'block') {
+  if (typeof shape === 'string' && isValidShape(shape)) {
+    return shape;
+  }
+
+  return fallback;
+}
+
+function slugifyName(name) {
+  if (typeof name !== 'string') {
+    return 'custom-furniture';
+  }
+
+  const base = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+
+  return base || 'custom-furniture';
+}
+
+function ensureUniqueFurnitureId(baseId) {
+  const base = baseId || 'custom-furniture';
+  let candidate = base;
+  let counter = 2;
+
+  const isTaken = (id) => palette.furniture.some((item) => item.id === id);
+
+  while (isTaken(candidate)) {
+    candidate = `${base}-${counter}`;
+    counter += 1;
+  }
+
+  return candidate;
+}
+
+export function createFurnitureDefinition(definition) {
+  const name = typeof definition?.name === 'string' && definition.name.trim().length > 0
+    ? definition.name.trim()
+    : 'Custom Furniture';
+
+  const desiredId = slugifyName(definition?.id ?? name);
+  const id = ensureUniqueFurnitureId(desiredId);
+
+  const normalized = {
+    id,
+    name,
+    description: typeof definition?.description === 'string' ? definition.description.trim() : '',
+    color: sanitizeHexColor(definition?.color, '#cccccc'),
+    shape: normalizeShape(definition?.shape, 'block'),
+    height: clampHeight(definition?.height, 48)
+  };
+
+  palette.furniture.push(normalized);
+  emitPaletteChange({ type: 'add', category: 'furniture', item: normalized });
+  return normalized;
+}
+
+export function updateFurnitureDefinition(id, updates) {
+  if (typeof id !== 'string' || id.length === 0) {
+    return null;
+  }
+
+  const index = palette.furniture.findIndex((item) => item.id === id);
+  if (index === -1) {
+    return null;
+  }
+
+  const current = palette.furniture[index];
+  const name =
+    typeof updates?.name === 'string' && updates.name.trim().length > 0
+      ? updates.name.trim()
+      : current.name;
+
+  const normalized = {
+    ...current,
+    name,
+    description:
+      typeof updates?.description === 'string'
+        ? updates.description.trim()
+        : current.description,
+    color: sanitizeHexColor(updates?.color, current.color),
+    shape: normalizeShape(updates?.shape, current.shape),
+    height: clampHeight(updates?.height, current.height)
+  };
+
+  palette.furniture[index] = normalized;
+  emitPaletteChange({ type: 'update', category: 'furniture', item: normalized });
+  return normalized;
+}
+
 export function findPaletteItem(category, id) {
   if (!palette[category]) {
     return null;

--- a/src/main.js
+++ b/src/main.js
@@ -4,9 +4,11 @@ import { InputController } from './game/InputController.js';
 import { createPaletteView } from './ui/paletteView.js';
 import { findPaletteItem, rotationLabels } from './game/palette.js';
 import { Avatar } from './game/Avatar.js';
+import { createFurnitureStudio } from './ui/furnitureStudio.js';
 
 const canvas = document.getElementById('gameCanvas');
 const paletteRoot = document.getElementById('paletteRoot');
+const furnitureStudioRoot = document.getElementById('furnitureStudioRoot');
 const rotateButton = document.getElementById('rotateButton');
 const rotationLabel = document.getElementById('rotationLabel');
 const tileIndicator = document.getElementById('tileIndicator');
@@ -19,6 +21,9 @@ const avatar = new Avatar(state);
 const renderer = new IsoRenderer(canvas, state, avatar);
 const input = new InputController(canvas, state, renderer, avatar);
 createPaletteView(paletteRoot, state);
+const furnitureStudio = furnitureStudioRoot
+  ? createFurnitureStudio(furnitureStudioRoot, state)
+  : null;
 
 state.onChange(() => {
   renderer.draw();
@@ -175,4 +180,7 @@ function updateZoomControls(event) {
 window.addEventListener('beforeunload', () => {
   input.destroy();
   renderer.destroy();
+  if (furnitureStudio && typeof furnitureStudio.destroy === 'function') {
+    furnitureStudio.destroy();
+  }
 });

--- a/src/ui/furnitureStudio.js
+++ b/src/ui/furnitureStudio.js
@@ -1,0 +1,442 @@
+import {
+  palette,
+  findPaletteItem,
+  onPaletteChange,
+  furnitureShapeOptions,
+  createFurnitureDefinition,
+  updateFurnitureDefinition
+} from '../game/palette.js';
+
+const HEIGHT_MIN = 12;
+const HEIGHT_MAX = 160;
+const DEFAULT_HEIGHT = 52;
+const DEFAULT_COLOR = '#cccccc';
+
+export function createFurnitureStudio(root, state) {
+  if (!root) {
+    throw new Error('Furniture studio root element not found.');
+  }
+
+  root.classList.add('furniture-studio');
+
+  const headerRow = document.createElement('div');
+  headerRow.className = 'studio-row';
+
+  const pickerLabel = document.createElement('label');
+  pickerLabel.className = 'studio-field';
+  const pickerLabelText = document.createElement('span');
+  pickerLabelText.textContent = 'Edit furniture';
+  const existingSelect = document.createElement('select');
+  existingSelect.className = 'studio-select';
+  existingSelect.setAttribute('aria-label', 'Choose furniture to edit');
+  pickerLabel.append(pickerLabelText, existingSelect);
+
+  const newButton = document.createElement('button');
+  newButton.type = 'button';
+  newButton.className = 'studio-secondary-button';
+  newButton.textContent = 'New furniture';
+  newButton.title = 'Start a fresh furniture design based on the current fields.';
+
+  headerRow.append(pickerLabel, newButton);
+
+  const form = document.createElement('form');
+  form.className = 'studio-form';
+  form.addEventListener('submit', (event) => event.preventDefault());
+
+  const modeIndicator = document.createElement('div');
+  modeIndicator.className = 'studio-mode-indicator';
+  modeIndicator.textContent = 'Select a furniture item to begin.';
+
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.required = true;
+  nameInput.maxLength = 48;
+  nameInput.placeholder = 'Name your furniture';
+  nameInput.className = 'studio-input';
+
+  const descriptionInput = document.createElement('textarea');
+  descriptionInput.rows = 3;
+  descriptionInput.maxLength = 160;
+  descriptionInput.placeholder = 'Describe the vibe or purpose of this piece.';
+  descriptionInput.className = 'studio-textarea';
+
+  const shapeSelect = document.createElement('select');
+  shapeSelect.className = 'studio-select';
+  furnitureShapeOptions.forEach((option) => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    shapeSelect.appendChild(opt);
+  });
+
+  const colorPicker = document.createElement('input');
+  colorPicker.type = 'color';
+  colorPicker.className = 'studio-color-input';
+  colorPicker.value = DEFAULT_COLOR;
+
+  const colorHexInput = document.createElement('input');
+  colorHexInput.type = 'text';
+  colorHexInput.className = 'studio-color-hex';
+  colorHexInput.value = DEFAULT_COLOR;
+  colorHexInput.maxLength = 7;
+  colorHexInput.spellcheck = false;
+  colorHexInput.autocapitalize = 'none';
+
+  const colorGroup = document.createElement('div');
+  colorGroup.className = 'studio-color-group';
+  colorGroup.append(colorPicker, colorHexInput);
+
+  const heightSlider = document.createElement('input');
+  heightSlider.type = 'range';
+  heightSlider.className = 'studio-range';
+  heightSlider.min = String(HEIGHT_MIN);
+  heightSlider.max = String(HEIGHT_MAX);
+  heightSlider.step = '2';
+  heightSlider.value = String(DEFAULT_HEIGHT);
+
+  const heightNumber = document.createElement('input');
+  heightNumber.type = 'number';
+  heightNumber.className = 'studio-number';
+  heightNumber.min = String(HEIGHT_MIN);
+  heightNumber.max = String(HEIGHT_MAX);
+  heightNumber.value = String(DEFAULT_HEIGHT);
+
+  const heightLabel = document.createElement('span');
+  heightLabel.className = 'studio-height-label';
+  heightLabel.textContent = `${DEFAULT_HEIGHT} px`;
+
+  const heightGroup = document.createElement('div');
+  heightGroup.className = 'studio-height-group';
+  heightGroup.append(heightSlider, heightNumber, heightLabel);
+
+  const saveButton = document.createElement('button');
+  saveButton.type = 'button';
+  saveButton.className = 'studio-primary-button';
+  saveButton.textContent = 'Save changes';
+
+  const duplicateButton = document.createElement('button');
+  duplicateButton.type = 'button';
+  duplicateButton.className = 'studio-secondary-button';
+  duplicateButton.textContent = 'Save as new';
+
+  const actionRow = document.createElement('div');
+  actionRow.className = 'studio-actions';
+  actionRow.append(saveButton, duplicateButton);
+
+  const statusEl = document.createElement('p');
+  statusEl.className = 'studio-status';
+  statusEl.setAttribute('role', 'status');
+  statusEl.setAttribute('aria-live', 'polite');
+  statusEl.textContent = 'Create remix furniture or tweak the classics.';
+
+  form.append(
+    modeIndicator,
+    createField('Display name', nameInput),
+    createField('Description', descriptionInput),
+    createField('Shape', shapeSelect),
+    createField('Base color', colorGroup),
+    createField('Height', heightGroup),
+    actionRow,
+    statusEl
+  );
+
+  root.append(headerRow, form);
+
+  let currentItemId = null;
+
+  const desiredInitialId =
+    state?.selectedCategory === 'furniture' ? state.selectedItemId : palette.furniture[0]?.id;
+  const activeId = refreshOptions(desiredInitialId);
+
+  if (activeId) {
+    loadFurniture(activeId);
+  } else {
+    enterCreateMode();
+  }
+
+  existingSelect.addEventListener('change', () => {
+    const selectedId = existingSelect.value;
+    if (selectedId && selectedId !== currentItemId) {
+      loadFurniture(selectedId);
+      if (state && typeof state.setSelection === 'function') {
+        state.setSelection('furniture', selectedId);
+      }
+    }
+  });
+
+  newButton.addEventListener('click', () => {
+    const template = currentItemId ? findPaletteItem('furniture', currentItemId) : null;
+    enterCreateMode(template || findPaletteItem('furniture', existingSelect.value));
+  });
+
+  colorPicker.addEventListener('input', () => {
+    colorHexInput.value = colorPicker.value;
+  });
+
+  colorHexInput.addEventListener('change', () => {
+    const normalized = normalizeColor(colorHexInput.value, colorPicker.value);
+    colorPicker.value = normalized;
+    colorHexInput.value = normalized;
+  });
+
+  heightSlider.addEventListener('input', () => {
+    const value = clampHeightValue(heightSlider.value);
+    heightNumber.value = String(value);
+    heightLabel.textContent = `${value} px`;
+  });
+
+  heightNumber.addEventListener('change', () => {
+    const value = clampHeightValue(heightNumber.value);
+    heightNumber.value = String(value);
+    heightSlider.value = String(value);
+    heightLabel.textContent = `${value} px`;
+  });
+
+  saveButton.addEventListener('click', () => {
+    if (!currentItemId) {
+      setStatus('Select a furniture item to update or create a new one first.', 'warning');
+      return;
+    }
+
+    const payload = readFormValues();
+    const updated = updateFurnitureDefinition(currentItemId, payload);
+    if (!updated) {
+      setStatus('Unable to save changes. Try again.', 'error');
+      return;
+    }
+
+    refreshOptions(updated.id);
+    loadFurniture(updated.id);
+    if (state && typeof state.refresh === 'function') {
+      state.refresh();
+    }
+    setStatus(`Saved changes to “${updated.name}”.`, 'success');
+  });
+
+  duplicateButton.addEventListener('click', () => {
+    const payload = readFormValues();
+    const created = createFurnitureDefinition(payload);
+    if (!created) {
+      setStatus('Unable to create furniture right now.', 'error');
+      return;
+    }
+
+    refreshOptions(created.id);
+    loadFurniture(created.id);
+    if (state) {
+      if (typeof state.setSelection === 'function') {
+        state.setSelection('furniture', created.id);
+      }
+      if (typeof state.refresh === 'function') {
+        state.refresh();
+      }
+    }
+    setStatus(`Minted a new piece named “${created.name}”.`, 'success');
+  });
+
+  nameInput.addEventListener('input', () => {
+    updateModeIndicator();
+  });
+
+  const unsubscribeState = state?.onChange
+    ? state.onChange(() => {
+        if (state.selectedCategory === 'furniture' && state.selectedItemId) {
+          if (state.selectedItemId !== currentItemId) {
+            refreshOptions(state.selectedItemId);
+            loadFurniture(state.selectedItemId);
+          }
+        }
+      })
+    : () => {};
+
+  const unsubscribePalette = onPaletteChange((event) => {
+    if (!event || event.category !== 'furniture') {
+      return;
+    }
+
+    const activeId = refreshOptions(currentItemId ?? event.item?.id);
+    if (currentItemId && activeId === currentItemId) {
+      loadFurniture(currentItemId);
+    }
+  });
+
+  function refreshOptions(forcedId) {
+    const items = Array.isArray(palette.furniture) ? palette.furniture : [];
+    const desiredId = typeof forcedId === 'string' ? forcedId : existingSelect.value;
+
+    existingSelect.innerHTML = '';
+
+    items.forEach((item) => {
+      const option = document.createElement('option');
+      option.value = item.id;
+      option.textContent = item.name;
+      existingSelect.appendChild(option);
+    });
+
+    if (items.length === 0) {
+      existingSelect.disabled = true;
+      currentItemId = null;
+      modeIndicator.textContent = 'Create your first furniture piece.';
+      saveButton.disabled = true;
+      duplicateButton.textContent = 'Create furniture';
+      return '';
+    }
+
+    existingSelect.disabled = false;
+
+    const fallbackId = items[0]?.id ?? '';
+    const targetId = items.some((item) => item.id === desiredId) ? desiredId : fallbackId;
+    if (targetId) {
+      existingSelect.value = targetId;
+    }
+
+    return targetId;
+  }
+
+  function loadFurniture(id) {
+    const definition = findPaletteItem('furniture', id);
+    if (!definition) {
+      return;
+    }
+
+    currentItemId = definition.id;
+
+    const color = normalizeColor(definition.color, DEFAULT_COLOR);
+    const height = clampHeightValue(definition.height);
+    const shape = normalizeShapeValue(definition.shape);
+
+    nameInput.value = definition.name ?? '';
+    descriptionInput.value = definition.description ?? '';
+    shapeSelect.value = shape;
+    colorPicker.value = color;
+    colorHexInput.value = color;
+    heightSlider.value = String(height);
+    heightNumber.value = String(height);
+    heightLabel.textContent = `${height} px`;
+
+    saveButton.disabled = false;
+    duplicateButton.textContent = 'Save as new';
+
+    modeIndicator.textContent = `Editing: ${definition.name}`;
+    setStatus(`Tuning “${definition.name}”.`, 'info');
+  }
+
+  function enterCreateMode(template) {
+    currentItemId = null;
+
+    const base = template || {
+      name: 'New Furniture',
+      description: '',
+      color: colorPicker.value,
+      shape: shapeSelect.value,
+      height: heightSlider.value
+    };
+
+    const color = normalizeColor(base.color, DEFAULT_COLOR);
+    const height = clampHeightValue(base.height);
+    const shape = normalizeShapeValue(base.shape);
+
+    nameInput.value = base.name ? `${base.name} Remix` : 'New Furniture';
+    descriptionInput.value = base.description ?? '';
+    shapeSelect.value = shape;
+    colorPicker.value = color;
+    colorHexInput.value = color;
+    heightSlider.value = String(height);
+    heightNumber.value = String(height);
+    heightLabel.textContent = `${height} px`;
+
+    saveButton.disabled = true;
+    duplicateButton.textContent = 'Create furniture';
+
+    updateModeIndicator();
+    setStatus('Ready to mint a fresh furniture entry.', 'info');
+  }
+
+  function readFormValues() {
+    const name = nameInput.value.trim();
+    const description = descriptionInput.value.trim();
+    const color = normalizeColor(colorPicker.value, DEFAULT_COLOR);
+    const shape = normalizeShapeValue(shapeSelect.value);
+    const height = clampHeightValue(heightNumber.value);
+
+    return {
+      name: name.length > 0 ? name : 'Custom Furniture',
+      description,
+      color,
+      shape,
+      height
+    };
+  }
+
+  function updateModeIndicator() {
+    if (currentItemId) {
+      modeIndicator.textContent = `Editing: ${nameInput.value.trim() || 'Furniture'}`;
+    } else {
+      const name = nameInput.value.trim();
+      modeIndicator.textContent = name ? `Creating: ${name}` : 'Creating new furniture';
+    }
+  }
+
+  function setStatus(message, tone = 'info') {
+    statusEl.textContent = message;
+    statusEl.dataset.tone = tone;
+  }
+
+  function normalizeColor(value, fallback) {
+    if (typeof value !== 'string') {
+      return fallback;
+    }
+
+    const trimmed = value.trim();
+    const six = trimmed.match(/^#?([0-9a-fA-F]{6})$/);
+    if (six) {
+      return `#${six[1].toLowerCase()}`;
+    }
+
+    const three = trimmed.match(/^#?([0-9a-fA-F]{3})$/);
+    if (three) {
+      const expanded = three[1]
+        .split('')
+        .map((char) => `${char}${char}`)
+        .join('');
+      return `#${expanded.toLowerCase()}`;
+    }
+
+    return fallback;
+  }
+
+  function clampHeightValue(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      return DEFAULT_HEIGHT;
+    }
+
+    const rounded = Math.round(numeric);
+    return Math.min(HEIGHT_MAX, Math.max(HEIGHT_MIN, rounded));
+  }
+
+  function normalizeShapeValue(value) {
+    const valid = furnitureShapeOptions.find((option) => option.id === value);
+    if (valid) {
+      return valid.id;
+    }
+
+    return furnitureShapeOptions[0]?.id ?? 'block';
+  }
+
+  function createField(labelText, control) {
+    const field = document.createElement('label');
+    field.className = 'studio-field';
+    const span = document.createElement('span');
+    span.textContent = labelText;
+    field.append(span, control);
+    return field;
+  }
+
+  return {
+    destroy() {
+      unsubscribeState();
+      unsubscribePalette();
+    }
+  };
+}

--- a/src/ui/paletteView.js
+++ b/src/ui/paletteView.js
@@ -1,4 +1,4 @@
-import { palette } from '../game/palette.js';
+import { palette, onPaletteChange } from '../game/palette.js';
 
 export function createPaletteView(root, state) {
   if (!root) {
@@ -69,9 +69,19 @@ export function createPaletteView(root, state) {
     updateSelectionDetails();
   });
 
+  const unsubscribePalette = onPaletteChange((event) => {
+    if (!event || event.category === currentCategory) {
+      renderItems(currentCategory);
+    }
+
+    updateActiveStates();
+    updateSelectionDetails();
+  });
+
   return {
     destroy() {
       unsubscribe();
+      unsubscribePalette();
     }
   };
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -252,6 +252,229 @@ h2 {
   gap: 1.25rem;
 }
 
+.studio-panel {
+  background: rgba(15, 18, 42, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 14px;
+  padding: 1.25rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.studio-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.studio-header h3 {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.studio-subtitle {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.studio-root {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.studio-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+}
+
+.studio-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.studio-mode-indicator {
+  align-self: flex-start;
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  background: rgba(255, 179, 71, 0.15);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+}
+
+.studio-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  flex: 1 1 200px;
+}
+
+.studio-field > span {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.studio-input,
+.studio-select,
+.studio-textarea,
+.studio-color-hex,
+.studio-number {
+  background: rgba(12, 15, 36, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  padding: 0.6rem 0.75rem;
+  font-family: 'Inter', sans-serif;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.studio-select {
+  min-width: 160px;
+}
+
+.studio-textarea {
+  resize: vertical;
+  min-height: 84px;
+}
+
+.studio-input:focus-visible,
+.studio-select:focus-visible,
+.studio-textarea:focus-visible,
+.studio-color-hex:focus-visible,
+.studio-number:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.55);
+  outline-offset: 2px;
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.studio-color-group {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.studio-color-input {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0;
+  cursor: pointer;
+}
+
+.studio-color-input::-webkit-color-swatch-wrapper {
+  padding: 0;
+  border-radius: 9px;
+}
+
+.studio-color-input::-webkit-color-swatch {
+  border: none;
+  border-radius: 9px;
+}
+
+.studio-color-hex {
+  width: 90px;
+  text-transform: uppercase;
+}
+
+.studio-height-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.studio-range {
+  flex: 1 1 auto;
+  accent-color: var(--accent);
+}
+
+.studio-number {
+  width: 72px;
+}
+
+.studio-height-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.studio-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.studio-primary-button,
+.studio-secondary-button {
+  border: 0;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  padding: 0.55rem 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.studio-primary-button {
+  background: linear-gradient(135deg, #ffe27d, #ffb347 55%, #ff8860);
+  color: #33230d;
+  box-shadow: 0 8px 18px rgba(255, 141, 0, 0.28);
+}
+
+.studio-primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(255, 141, 0, 0.34);
+}
+
+.studio-secondary-button {
+  background: linear-gradient(135deg, rgba(120, 240, 255, 0.3), rgba(122, 181, 255, 0.45));
+  color: var(--text-primary);
+  border: 1px solid rgba(142, 170, 255, 0.45);
+}
+
+.studio-secondary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(118, 178, 255, 0.28);
+}
+
+.studio-primary-button:disabled,
+.studio-secondary-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.studio-status {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.studio-status[data-tone='success'] {
+  color: #8cffd1;
+}
+
+.studio-status[data-tone='error'] {
+  color: #ff7a7a;
+}
+
+.studio-status[data-tone='warning'] {
+  color: #ffd27f;
+}
+
 .palette-categories {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));


### PR DESCRIPTION
## Summary
- add a furniture studio panel with form controls for editing or minting furniture definitions
- expose palette mutation helpers and change notifications so the palette and renderer react to definition changes
- wire the studio into the app shell and extend styling for the new controls

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d0dc11ccfc8332a525922a92dd741c