### PR TITLE
Add furniture studio for creating and editing items

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,13 @@
             Pick a floor style or furnish the space. Left click to place, right click to remove furniture. Switch to walk mode to send the avatar exploring.
           </p>
           <div id="paletteRoot" class="palette-root"></div>
+          <section class="studio-panel">
+            <h3>Furniture Studio</h3>
+            <p class="panel-description studio-description">
+              Craft new furniture prototypes or tweak existing pieces. Saved changes update every placed copy in the room.
+            </p>
+            <div id="furnitureStudioRoot"></div>
+          </section>
           <div class="legend">
             <h3>Controls</h3>
             <ul>

--- a/src/game/palette.js
+++ b/src/game/palette.js
@@ -61,7 +61,66 @@ export const palette = {
   ]
 };
 
+export const furnitureShapeOptions = [
+  { id: 'retro-sofa', label: 'Retro Sofa' },
+  { id: 'lofi-table', label: 'Lofi Table' },
+  { id: 'neon-lamp', label: 'Neon Lamp' },
+  { id: 'palm-plant', label: 'Palm Plant' },
+  { id: 'block', label: 'Basic Block' }
+];
+
+const FURNITURE_HEIGHT_MIN = 12;
+const FURNITURE_HEIGHT_MAX = 96;
+const DEFAULT_FURNITURE_HEIGHT = 48;
+
+export const furnitureHeightRange = {
+  min: FURNITURE_HEIGHT_MIN,
+  max: FURNITURE_HEIGHT_MAX,
+  default: DEFAULT_FURNITURE_HEIGHT
+};
+
+const paletteListeners = new Set();
+
 export const rotationLabels = ['North-East', 'South-East', 'South-West', 'North-West'];
+
+export function onPaletteChange(listener) {
+  if (typeof listener !== 'function') {
+    return () => {};
+  }
+
+  paletteListeners.add(listener);
+  return () => {
+    paletteListeners.delete(listener);
+  };
+}
+
+export function addFurnitureDefinition(definition) {
+  const sanitized = sanitizeFurnitureDefinition(definition);
+  const existingIndex = palette.furniture.findIndex((item) => item.id === sanitized.id);
+
+  if (existingIndex >= 0) {
+    palette.furniture[existingIndex] = sanitized;
+    notifyPaletteChange('furniture', 'update', sanitized);
+    return sanitized;
+  }
+
+  palette.furniture.push(sanitized);
+  notifyPaletteChange('furniture', 'add', sanitized);
+  return sanitized;
+}
+
+export function updateFurnitureDefinition(id, updates) {
+  const index = palette.furniture.findIndex((item) => item.id === id);
+  if (index < 0) {
+    return null;
+  }
+
+  const merged = { ...palette.furniture[index], ...updates, id };
+  const sanitized = sanitizeFurnitureDefinition(merged);
+  palette.furniture[index] = sanitized;
+  notifyPaletteChange('furniture', 'update', sanitized);
+  return sanitized;
+}
 
 export function findPaletteItem(category, id) {
   if (!palette[category]) {
@@ -73,4 +132,114 @@ export function findPaletteItem(category, id) {
 
 export function getDefaultSelection() {
   return { category: 'floor', itemId: palette.floor[0].id };
+}
+
+function notifyPaletteChange(category, type, definition) {
+  paletteListeners.forEach((listener) => {
+    listener({ category, type, definition });
+  });
+}
+
+function sanitizeFurnitureDefinition(source) {
+  const id = normalizeId(source?.id);
+  if (!id) {
+    throw new Error('Furniture definition requires an id.');
+  }
+
+  return {
+    id,
+    name: normalizeName(source?.name, 'Untitled Furniture'),
+    color: normalizeColor(source?.color, '#cccccc'),
+    shape: normalizeShape(source?.shape, 'block'),
+    height: clampHeight(source?.height, DEFAULT_FURNITURE_HEIGHT),
+    description: normalizeDescription(source?.description)
+  };
+}
+
+function normalizeId(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+}
+
+function normalizeName(value, fallback) {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+
+  if (typeof fallback === 'string') {
+    const trimmedFallback = fallback.trim();
+    if (trimmedFallback) {
+      return trimmedFallback;
+    }
+  }
+
+  return 'Untitled Furniture';
+}
+
+function normalizeColor(value, fallback) {
+  const candidate = typeof value === 'string' ? value.trim() : '';
+
+  if (isValidHex(candidate)) {
+    return normalizeHex(candidate);
+  }
+
+  if (isValidHex(fallback)) {
+    return normalizeHex(fallback);
+  }
+
+  return '#cccccc';
+}
+
+function normalizeShape(value, fallback) {
+  const candidate = typeof value === 'string' ? value.trim() : '';
+  if (candidate) {
+    return candidate;
+  }
+
+  if (typeof fallback === 'string' && fallback.trim()) {
+    return fallback.trim();
+  }
+
+  return 'block';
+}
+
+function normalizeDescription(value) {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  return value.trim();
+}
+
+function clampHeight(value, fallback) {
+  const numeric = Number.isFinite(value) ? value : Number.parseFloat(value);
+  const base = Number.isFinite(numeric) ? numeric : Number.isFinite(fallback) ? fallback : DEFAULT_FURNITURE_HEIGHT;
+  const rounded = Math.round(base);
+  return Math.max(FURNITURE_HEIGHT_MIN, Math.min(FURNITURE_HEIGHT_MAX, rounded));
+}
+
+function isValidHex(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(value.trim());
+}
+
+function normalizeHex(value) {
+  const hex = value.trim().toLowerCase();
+  if (hex.length === 4) {
+    const r = hex[1];
+    const g = hex[2];
+    const b = hex[3];
+    return `#${r}${r}${g}${g}${b}${b}`;
+  }
+
+  return hex;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,11 +2,13 @@ import { GameState } from './game/GameState.js';
 import { IsoRenderer } from './game/IsoRenderer.js';
 import { InputController } from './game/InputController.js';
 import { createPaletteView } from './ui/paletteView.js';
-import { findPaletteItem, rotationLabels } from './game/palette.js';
+import { createFurnitureStudio } from './ui/furnitureStudio.js';
+import { findPaletteItem, rotationLabels, onPaletteChange } from './game/palette.js';
 import { Avatar } from './game/Avatar.js';
 
 const canvas = document.getElementById('gameCanvas');
 const paletteRoot = document.getElementById('paletteRoot');
+const furnitureStudioRoot = document.getElementById('furnitureStudioRoot');
 const rotateButton = document.getElementById('rotateButton');
 const rotationLabel = document.getElementById('rotationLabel');
 const tileIndicator = document.getElementById('tileIndicator');
@@ -18,7 +20,11 @@ const state = new GameState(14, 14);
 const avatar = new Avatar(state);
 const renderer = new IsoRenderer(canvas, state, avatar);
 const input = new InputController(canvas, state, renderer, avatar);
-createPaletteView(paletteRoot, state);
+const paletteView = createPaletteView(paletteRoot, state);
+const furnitureStudio = createFurnitureStudio(furnitureStudioRoot, state);
+const unsubscribePaletteChange = onPaletteChange(() => {
+  state.notifyChange();
+});
 
 state.onChange(() => {
   renderer.draw();
@@ -175,4 +181,7 @@ function updateZoomControls(event) {
 window.addEventListener('beforeunload', () => {
   input.destroy();
   renderer.destroy();
+  paletteView?.destroy?.();
+  furnitureStudio?.destroy?.();
+  unsubscribePaletteChange?.();
 });

--- a/src/ui/furnitureStudio.js
+++ b/src/ui/furnitureStudio.js
@@ -1,0 +1,581 @@
+import {
+  palette,
+  findPaletteItem,
+  addFurnitureDefinition,
+  updateFurnitureDefinition,
+  onPaletteChange,
+  furnitureShapeOptions,
+  furnitureHeightRange
+} from '../game/palette.js';
+
+const DEFAULT_NEW_COLOR = '#8bd8ff';
+const DEFAULT_SHAPE = 'block';
+const HEX_SIX = /^#([0-9a-fA-F]{6})$/;
+const HEX_THREE = /^#([0-9a-fA-F]{3})$/;
+
+export function createFurnitureStudio(root, state) {
+  if (!root) {
+    return {
+      destroy() {}
+    };
+  }
+
+  root.innerHTML = '';
+
+  const cleanupFns = [];
+  const addListener = (target, type, handler) => {
+    target.addEventListener(type, handler);
+    cleanupFns.push(() => target.removeEventListener(type, handler));
+  };
+
+  const idSuffix = Math.random().toString(36).slice(2, 8);
+  const selectId = `studio-existing-${idSuffix}`;
+  const nameInputId = `studio-name-${idSuffix}`;
+  const colorInputId = `studio-color-${idSuffix}`;
+  const heightInputId = `studio-height-${idSuffix}`;
+  const shapeSelectId = `studio-shape-${idSuffix}`;
+  const descriptionId = `studio-description-${idSuffix}`;
+
+  const container = document.createElement('div');
+  container.className = 'furniture-studio';
+
+  const toolbar = document.createElement('div');
+  toolbar.className = 'studio-toolbar';
+  container.appendChild(toolbar);
+
+  const toolbarGroup = document.createElement('div');
+  toolbarGroup.className = 'studio-toolbar-group';
+  toolbar.appendChild(toolbarGroup);
+
+  const modeChip = document.createElement('span');
+  modeChip.className = 'studio-mode-chip';
+  toolbarGroup.appendChild(modeChip);
+
+  const selectWrapper = document.createElement('div');
+  selectWrapper.className = 'studio-select-wrapper';
+  toolbarGroup.appendChild(selectWrapper);
+
+  const selectLabel = document.createElement('label');
+  selectLabel.className = 'studio-select-label';
+  selectLabel.htmlFor = selectId;
+  selectLabel.textContent = 'Edit existing';
+  selectWrapper.appendChild(selectLabel);
+
+  const existingSelect = document.createElement('select');
+  existingSelect.id = selectId;
+  existingSelect.className = 'studio-select';
+  selectWrapper.appendChild(existingSelect);
+
+  const newButton = document.createElement('button');
+  newButton.type = 'button';
+  newButton.className = 'studio-new-button';
+  newButton.textContent = 'New furniture prototype';
+  toolbar.appendChild(newButton);
+
+  const idDisplay = document.createElement('div');
+  idDisplay.className = 'studio-id';
+  container.appendChild(idDisplay);
+
+  const tip = document.createElement('p');
+  tip.className = 'studio-tip';
+  tip.textContent = 'Tip: Saving applies updates to every placed copy instantly.';
+  container.appendChild(tip);
+
+  const form = document.createElement('form');
+  form.className = 'studio-form';
+  form.setAttribute('novalidate', 'novalidate');
+  container.appendChild(form);
+
+  const nameField = document.createElement('div');
+  nameField.className = 'studio-field';
+  const nameLabel = document.createElement('label');
+  nameLabel.className = 'studio-field-label';
+  nameLabel.htmlFor = nameInputId;
+  nameLabel.textContent = 'Display name';
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.id = nameInputId;
+  nameInput.placeholder = 'Neon Bar Stool';
+  nameField.append(nameLabel, nameInput);
+  form.appendChild(nameField);
+
+  const colorField = document.createElement('div');
+  colorField.className = 'studio-field';
+  const colorLabel = document.createElement('label');
+  colorLabel.className = 'studio-field-label';
+  colorLabel.htmlFor = colorInputId;
+  colorLabel.textContent = 'Accent colour';
+  const colorRow = document.createElement('div');
+  colorRow.className = 'studio-color-row';
+  const colorInput = document.createElement('input');
+  colorInput.type = 'color';
+  colorInput.id = colorInputId;
+  colorInput.className = 'studio-color-input';
+  const colorValue = document.createElement('span');
+  colorValue.className = 'studio-color-value';
+  colorRow.append(colorInput, colorValue);
+  colorField.append(colorLabel, colorRow);
+  form.appendChild(colorField);
+
+  const heightField = document.createElement('div');
+  heightField.className = 'studio-field';
+  const heightLabel = document.createElement('label');
+  heightLabel.className = 'studio-field-label';
+  heightLabel.htmlFor = heightInputId;
+  heightLabel.textContent = 'Height';
+  const heightRow = document.createElement('div');
+  heightRow.className = 'studio-height-row';
+  const heightInput = document.createElement('input');
+  heightInput.type = 'range';
+  heightInput.id = heightInputId;
+  heightInput.className = 'studio-height-slider';
+  const heightValue = document.createElement('span');
+  heightValue.className = 'studio-height-value';
+  heightRow.append(heightInput, heightValue);
+  heightField.append(heightLabel, heightRow);
+  form.appendChild(heightField);
+
+  const shapeField = document.createElement('div');
+  shapeField.className = 'studio-field';
+  const shapeLabel = document.createElement('label');
+  shapeLabel.className = 'studio-field-label';
+  shapeLabel.htmlFor = shapeSelectId;
+  shapeLabel.textContent = 'Shape preset';
+  const shapeSelect = document.createElement('select');
+  shapeSelect.id = shapeSelectId;
+  shapeSelect.className = 'studio-shape-select';
+  furnitureShapeOptions.forEach((option) => {
+    const opt = document.createElement('option');
+    opt.value = option.id;
+    opt.textContent = option.label;
+    shapeSelect.appendChild(opt);
+  });
+  shapeField.append(shapeLabel, shapeSelect);
+  form.appendChild(shapeField);
+
+  const descriptionField = document.createElement('div');
+  descriptionField.className = 'studio-field';
+  const descriptionLabel = document.createElement('label');
+  descriptionLabel.className = 'studio-field-label';
+  descriptionLabel.htmlFor = descriptionId;
+  descriptionLabel.textContent = 'Description';
+  const descriptionInput = document.createElement('textarea');
+  descriptionInput.id = descriptionId;
+  descriptionInput.placeholder = 'What vibe does this piece add to the room?';
+  descriptionField.append(descriptionLabel, descriptionInput);
+  form.appendChild(descriptionField);
+
+  const submitButton = document.createElement('button');
+  submitButton.type = 'submit';
+  submitButton.className = 'studio-submit';
+  form.appendChild(submitButton);
+
+  const status = document.createElement('div');
+  status.className = 'studio-status';
+  status.setAttribute('aria-live', 'polite');
+  container.appendChild(status);
+
+  root.appendChild(container);
+
+  const sliderMin = Number.isFinite(furnitureHeightRange?.min) ? furnitureHeightRange.min : 12;
+  const sliderMax = Number.isFinite(furnitureHeightRange?.max) ? furnitureHeightRange.max : 96;
+  const sliderDefault = Number.isFinite(furnitureHeightRange?.default)
+    ? furnitureHeightRange.default
+    : Math.round((sliderMin + sliderMax) / 2);
+  heightInput.min = String(sliderMin);
+  heightInput.max = String(sliderMax);
+  heightInput.step = '1';
+
+  let mode = 'edit';
+  let editingId = null;
+  let lastEditedId = null;
+  let draft = createEmptyDraft(sliderDefault);
+
+  const initialSelection =
+    state?.selectedCategory === 'furniture'
+      ? findPaletteItem('furniture', state.selectedItemId)
+      : null;
+
+  if (initialSelection) {
+    editingId = initialSelection.id;
+    lastEditedId = initialSelection.id;
+    draft = createDraftFromDefinition(initialSelection, sliderDefault, sliderMin, sliderMax);
+  } else if (palette.furniture.length > 0) {
+    editingId = palette.furniture[0].id;
+    lastEditedId = editingId;
+    draft = createDraftFromDefinition(
+      findPaletteItem('furniture', editingId),
+      sliderDefault,
+      sliderMin,
+      sliderMax
+    );
+  } else {
+    mode = 'create';
+  }
+
+  refreshExistingOptions();
+  applyDraftToInputs();
+  updateModeChip();
+  updateIdDisplay();
+  updateSubmitLabel();
+  updateSubmitDisabled();
+
+  addListener(existingSelect, 'change', () => {
+    if (!existingSelect.value) {
+      return;
+    }
+
+    editingId = existingSelect.value;
+    lastEditedId = editingId;
+    mode = 'edit';
+    draft = createDraftFromDefinition(
+      findPaletteItem('furniture', editingId),
+      sliderDefault,
+      sliderMin,
+      sliderMax
+    );
+    clearStatus();
+    applyDraftToInputs();
+    updateModeChip();
+    updateIdDisplay();
+    updateSubmitLabel();
+    updateSubmitDisabled();
+  });
+
+  addListener(newButton, 'click', () => {
+    mode = 'create';
+    editingId = null;
+    draft = createEmptyDraft(sliderDefault);
+    clearStatus();
+    applyDraftToInputs();
+    updateModeChip();
+    updateIdDisplay();
+    updateSubmitLabel();
+    updateSubmitDisabled();
+    nameInput.focus({ preventScroll: true });
+  });
+
+  addListener(nameInput, 'input', () => {
+    draft.name = nameInput.value;
+    clearStatus();
+    updateSubmitDisabled();
+  });
+
+  addListener(colorInput, 'input', () => {
+    draft.color = normalizeColorHex(colorInput.value, DEFAULT_NEW_COLOR);
+    colorValue.textContent = draft.color.toUpperCase();
+    clearStatus();
+  });
+
+  addListener(heightInput, 'input', () => {
+    const newValue = clampHeightWithinRange(heightInput.value, sliderDefault, sliderMin, sliderMax);
+    draft.height = newValue;
+    heightInput.value = String(newValue);
+    heightValue.textContent = `${newValue} px`;
+    clearStatus();
+  });
+
+  addListener(shapeSelect, 'change', () => {
+    draft.shape = shapeSelect.value || DEFAULT_SHAPE;
+    clearStatus();
+  });
+
+  addListener(descriptionInput, 'input', () => {
+    draft.description = descriptionInput.value;
+    clearStatus();
+  });
+
+  addListener(form, 'submit', (event) => {
+    event.preventDefault();
+    const trimmedName = draft.name.trim();
+    if (!trimmedName) {
+      setStatus('Give your furniture a name before saving.', 'error');
+      nameInput.focus({ preventScroll: true });
+      return;
+    }
+
+    const payload = {
+      name: trimmedName,
+      color: draft.color,
+      height: clampHeightWithinRange(draft.height, sliderDefault, sliderMin, sliderMax),
+      shape: draft.shape || DEFAULT_SHAPE,
+      description: draft.description.trim()
+    };
+
+    if (mode === 'create') {
+      const existingIds = palette.furniture.map((item) => item.id);
+      const newId = generateUniqueId(trimmedName, existingIds);
+      const created = addFurnitureDefinition({ id: newId, ...payload });
+      mode = 'edit';
+      editingId = created.id;
+      lastEditedId = created.id;
+      draft = createDraftFromDefinition(created, sliderDefault, sliderMin, sliderMax);
+      refreshExistingOptions();
+      applyDraftToInputs();
+      updateModeChip();
+      updateIdDisplay();
+      updateSubmitLabel();
+      updateSubmitDisabled();
+      setStatus(`Created "${created.name}". It's ready to place!`, 'success');
+      state?.setSelection?.('furniture', created.id);
+      return;
+    }
+
+    if (editingId) {
+      const updated = updateFurnitureDefinition(editingId, payload);
+      if (!updated) {
+        setStatus('Unable to update this furniture item.', 'error');
+        return;
+      }
+
+      draft = createDraftFromDefinition(updated, sliderDefault, sliderMin, sliderMax);
+      refreshExistingOptions();
+      applyDraftToInputs();
+      updateSubmitDisabled();
+      setStatus(`Updated "${updated.name}". All copies refreshed.`, 'success');
+    }
+  });
+
+  const removePaletteListener = onPaletteChange(() => {
+    refreshExistingOptions();
+    if (mode === 'edit' && editingId) {
+      const definition = findPaletteItem('furniture', editingId);
+      if (definition) {
+        draft = createDraftFromDefinition(definition, sliderDefault, sliderMin, sliderMax);
+        applyDraftToInputs();
+        updateSubmitDisabled();
+      }
+    } else if (palette.furniture.length === 0 && mode !== 'create') {
+      mode = 'create';
+      editingId = null;
+      lastEditedId = null;
+      draft = createEmptyDraft(sliderDefault);
+      clearStatus();
+      applyDraftToInputs();
+      updateModeChip();
+      updateIdDisplay();
+      updateSubmitLabel();
+      updateSubmitDisabled();
+    }
+  });
+  cleanupFns.push(removePaletteListener);
+
+  return {
+    destroy() {
+      cleanupFns.forEach((fn) => fn());
+    }
+  };
+
+  function refreshExistingOptions() {
+    const items = palette.furniture;
+    existingSelect.innerHTML = '';
+
+    if (!items.length) {
+      existingSelect.disabled = true;
+      const placeholder = document.createElement('option');
+      placeholder.value = '';
+      placeholder.textContent = 'No furniture prototypes yet';
+      placeholder.disabled = true;
+      placeholder.selected = true;
+      existingSelect.appendChild(placeholder);
+      return;
+    }
+
+    existingSelect.disabled = false;
+    items.forEach((item) => {
+      const option = document.createElement('option');
+      option.value = item.id;
+      option.textContent = item.name ?? item.id;
+      existingSelect.appendChild(option);
+    });
+
+    const targetId = (mode === 'edit' ? editingId : lastEditedId) ?? items[0].id;
+    if (targetId && items.some((item) => item.id === targetId)) {
+      existingSelect.value = targetId;
+      if (mode !== 'edit') {
+        lastEditedId = targetId;
+      }
+    } else {
+      existingSelect.value = items[0].id;
+      if (mode === 'edit') {
+        editingId = items[0].id;
+      }
+      lastEditedId = items[0].id;
+    }
+  }
+
+  function applyDraftToInputs() {
+    draft.color = normalizeColorHex(draft.color, DEFAULT_NEW_COLOR);
+    colorInput.value = draft.color;
+    colorValue.textContent = draft.color.toUpperCase();
+
+    const height = clampHeightWithinRange(draft.height, sliderDefault, sliderMin, sliderMax);
+    draft.height = height;
+    heightInput.value = String(height);
+    heightValue.textContent = `${height} px`;
+
+    const shape = draft.shape || DEFAULT_SHAPE;
+    draft.shape = shape;
+    ensureShapeOption(shapeSelect, shape);
+    shapeSelect.value = shape;
+
+    draft.name = draft.name ?? '';
+    nameInput.value = draft.name;
+
+    draft.description = typeof draft.description === 'string' ? draft.description : '';
+    descriptionInput.value = draft.description;
+  }
+
+  function updateModeChip() {
+    if (mode === 'create') {
+      modeChip.textContent = 'Mode: New prototype';
+      modeChip.dataset.mode = 'create';
+    } else {
+      modeChip.textContent = 'Mode: Editing existing';
+      modeChip.dataset.mode = 'edit';
+    }
+  }
+
+  function updateIdDisplay() {
+    idDisplay.innerHTML = '';
+    if (mode === 'edit' && editingId) {
+      const label = document.createElement('span');
+      label.textContent = 'Furniture ID:';
+      const code = document.createElement('code');
+      code.textContent = editingId;
+      idDisplay.append(label, code);
+    } else {
+      idDisplay.textContent = 'ID will be generated when you save.';
+    }
+  }
+
+  function updateSubmitLabel() {
+    submitButton.textContent = mode === 'create' ? 'Create furniture' : 'Save changes';
+  }
+
+  function updateSubmitDisabled() {
+    submitButton.disabled = draft.name.trim().length === 0;
+  }
+
+  function setStatus(message, stateName) {
+    status.textContent = message;
+    if (stateName) {
+      status.dataset.state = stateName;
+    } else {
+      delete status.dataset.state;
+    }
+  }
+
+  function clearStatus() {
+    setStatus('', null);
+  }
+}
+
+function createEmptyDraft(defaultHeight) {
+  return {
+    name: '',
+    color: DEFAULT_NEW_COLOR,
+    height: defaultHeight,
+    shape: DEFAULT_SHAPE,
+    description: ''
+  };
+}
+
+function createDraftFromDefinition(definition, defaultHeight, minHeight, maxHeight) {
+  if (!definition) {
+    return createEmptyDraft(defaultHeight);
+  }
+
+  return {
+    name: typeof definition.name === 'string' ? definition.name : '',
+    color: normalizeColorHex(definition.color, DEFAULT_NEW_COLOR),
+    height: clampHeightWithinRange(definition.height, defaultHeight, minHeight, maxHeight),
+    shape: definition.shape || DEFAULT_SHAPE,
+    description: typeof definition.description === 'string' ? definition.description : ''
+  };
+}
+
+function clampHeightWithinRange(value, fallback, min, max) {
+  const numeric = Number.isFinite(value) ? value : Number.parseFloat(value);
+  const safeFallback = Number.isFinite(fallback) ? fallback : Math.round((min + max) / 2);
+  const base = Number.isFinite(numeric) ? numeric : safeFallback;
+  const rounded = Math.round(base);
+  return Math.max(min, Math.min(max, rounded));
+}
+
+function normalizeColorHex(value, fallback = DEFAULT_NEW_COLOR) {
+  const candidate = parseColorHex(value);
+  if (candidate) {
+    return candidate;
+  }
+
+  const fallbackCandidate = parseColorHex(fallback);
+  if (fallbackCandidate) {
+    return fallbackCandidate;
+  }
+
+  return DEFAULT_NEW_COLOR;
+}
+
+function parseColorHex(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (HEX_SIX.test(trimmed)) {
+    return `#${trimmed.slice(1).toLowerCase()}`;
+  }
+
+  if (HEX_THREE.test(trimmed)) {
+    const r = trimmed[1];
+    const g = trimmed[2];
+    const b = trimmed[3];
+    return `#${r}${r}${g}${g}${b}${b}`.toLowerCase();
+  }
+
+  return null;
+}
+
+function ensureShapeOption(select, shapeId) {
+  if (!shapeId) {
+    return;
+  }
+
+  const exists = Array.from(select.options).some((option) => option.value === shapeId);
+  if (exists) {
+    return;
+  }
+
+  const option = document.createElement('option');
+  option.value = shapeId;
+  option.textContent = `Custom (${shapeId})`;
+  select.appendChild(option);
+}
+
+function generateUniqueId(name, existingIds) {
+  const taken = new Set(existingIds);
+  const base = slugifyName(name) || 'custom-item';
+  let candidate = base;
+  let suffix = 2;
+
+  while (taken.has(candidate)) {
+    candidate = `${base}-${suffix}`;
+    suffix += 1;
+  }
+
+  return candidate;
+}
+
+function slugifyName(name) {
+  if (typeof name !== 'string') {
+    return '';
+  }
+
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+}

--- a/src/ui/paletteView.js
+++ b/src/ui/paletteView.js
@@ -1,4 +1,4 @@
-import { palette } from '../game/palette.js';
+import { palette, onPaletteChange } from '../game/palette.js';
 
 export function createPaletteView(root, state) {
   if (!root) {
@@ -59,7 +59,7 @@ export function createPaletteView(root, state) {
   updateActiveStates();
   updateSelectionDetails();
 
-  const unsubscribe = state.onChange(() => {
+  const unsubscribeState = state.onChange(() => {
     if (state.selectedCategory !== currentCategory) {
       currentCategory = state.selectedCategory;
       renderItems(currentCategory);
@@ -69,9 +69,16 @@ export function createPaletteView(root, state) {
     updateSelectionDetails();
   });
 
+  const unsubscribePalette = onPaletteChange(() => {
+    renderItems(currentCategory);
+    updateActiveStates();
+    updateSelectionDetails();
+  });
+
   return {
     destroy() {
-      unsubscribe();
+      unsubscribeState();
+      unsubscribePalette();
     }
   };
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -252,6 +252,299 @@ h2 {
   gap: 1.25rem;
 }
 
+.studio-panel {
+  background: rgba(12, 15, 34, 0.86);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.studio-panel h3 {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.studio-description {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.furniture-studio {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.studio-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.studio-toolbar-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 0.75rem;
+  flex: 1 1 180px;
+}
+
+.studio-mode-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(12, 16, 40, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.studio-mode-chip[data-mode='create'] {
+  color: #82f5c8;
+  border-color: rgba(130, 245, 200, 0.45);
+  background: rgba(9, 24, 24, 0.85);
+}
+
+.studio-select-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  flex: 1 1 180px;
+}
+
+.studio-select-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.studio-select {
+  background: rgba(18, 21, 54, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  color: var(--text-primary);
+  padding: 0.6rem 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.studio-select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.studio-select:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 2px;
+}
+
+.studio-new-button {
+  background: linear-gradient(135deg, rgba(122, 250, 210, 0.85), rgba(92, 167, 255, 0.85));
+  color: #07112e;
+  border: 0;
+  border-radius: 10px;
+  padding: 0.6rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 8px 18px rgba(92, 167, 255, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.studio-new-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(92, 167, 255, 0.34);
+}
+
+.studio-new-button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 2px;
+}
+
+.studio-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.studio-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.studio-field-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.studio-field input[type='text'],
+.studio-field textarea {
+  background: rgba(16, 19, 46, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  color: var(--text-primary);
+  font-size: 0.85rem;
+  font-family: 'Inter', sans-serif;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.studio-field input[type='text']:focus,
+.studio-field textarea:focus {
+  outline: none;
+  border-color: rgba(255, 179, 71, 0.8);
+  box-shadow: 0 0 0 2px rgba(255, 179, 71, 0.18);
+}
+
+.studio-field textarea {
+  min-height: 72px;
+  resize: vertical;
+}
+
+.studio-color-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.studio-color-input {
+  width: 48px;
+  height: 32px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+}
+
+.studio-color-input:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 2px;
+}
+
+.studio-color-input::-webkit-color-swatch {
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.studio-color-input::-moz-color-swatch {
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.studio-color-value {
+  font-weight: 600;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.studio-height-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.studio-height-slider {
+  flex: 1;
+  accent-color: var(--accent);
+}
+
+.studio-height-value {
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 3ch;
+  text-align: right;
+  font-size: 0.85rem;
+}
+
+.studio-shape-select {
+  background: rgba(16, 19, 46, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  color: var(--text-primary);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+}
+
+.studio-shape-select:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 2px;
+}
+
+.studio-tip {
+  margin: 0;
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.55);
+  background: rgba(9, 12, 32, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  line-height: 1.5;
+}
+
+.studio-submit {
+  align-self: flex-start;
+  background: linear-gradient(135deg, #ffe27d, #ffb347 55%, #ff8860);
+  color: #33230d;
+  border: 0;
+  border-radius: 12px;
+  padding: 0.65rem 1.2rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(255, 135, 73, 0.26);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.studio-submit:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(255, 135, 73, 0.3);
+}
+
+.studio-submit:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.studio-submit:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.7);
+  outline-offset: 2px;
+}
+
+.studio-status {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  min-height: 1.2em;
+}
+
+.studio-status[data-state='success'] {
+  color: #82f5c8;
+}
+
+.studio-status[data-state='error'] {
+  color: #ff9aa2;
+}
+
 .palette-categories {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));


### PR DESCRIPTION
## Summary
- add an interactive furniture studio for crafting new furniture pieces or editing existing definitions directly in the app
- extend the palette module with change notifications, shape presets, and height bounds so new furniture metadata is validated
- wire palette change notifications into the main loop and palette view so renders and selection lists update automatically

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d0dc11ccfc8332a525922a92dd741c